### PR TITLE
Support export of QAT finalized models

### DIFF
--- a/mct_quantizers/keras/activation_quantization_holder.py
+++ b/mct_quantizers/keras/activation_quantization_holder.py
@@ -16,6 +16,8 @@
 
 from mct_quantizers.common.base_inferable_quantizer import BaseInferableQuantizer
 from mct_quantizers.common.constants import ACTIVATION_HOLDER_QUANTIZER, FOUND_TF, TRAINING, STEPS
+from mct_quantizers.common.get_all_subclasses import get_all_subclasses
+from mct_quantizers.keras.quantizers import BaseKerasInferableQuantizer
 from mct_quantizers.logger import Logger
 
 if FOUND_TF:
@@ -74,10 +76,12 @@ if FOUND_TF:
             Returns: A ActivationQuantizationHolder object
 
             """
+            qi_inferable_custom_objects = {subclass.__name__: subclass for subclass in
+                                           get_all_subclasses(BaseKerasInferableQuantizer)}
             config = config.copy()
             activation_holder_quantizer = keras.utils.deserialize_keras_object(config.pop(ACTIVATION_HOLDER_QUANTIZER),
                                                                                module_objects=globals(),
-                                                                               custom_objects=None)
+                                                                               custom_objects=qi_inferable_custom_objects)
 
             return cls(activation_holder_quantizer=activation_holder_quantizer,
                        **config)
@@ -138,6 +142,7 @@ if FOUND_TF:
             if hasattr(self.activation_holder_quantizer, 'convert2inferable') and callable(
                     self.activation_holder_quantizer.convert2inferable):  # pragma: no cover
                 self.activation_holder_quantizer = self.activation_holder_quantizer.convert2inferable()
+                return self.from_config(self.get_config()) # return new layer with no weights. It assumes holder of inferable quantizers have no weights
 
 
 else:

--- a/mct_quantizers/keras/activation_quantization_holder.py
+++ b/mct_quantizers/keras/activation_quantization_holder.py
@@ -17,13 +17,14 @@
 from mct_quantizers.common.base_inferable_quantizer import BaseInferableQuantizer
 from mct_quantizers.common.constants import ACTIVATION_HOLDER_QUANTIZER, FOUND_TF, TRAINING, STEPS
 from mct_quantizers.common.get_all_subclasses import get_all_subclasses
-from mct_quantizers.keras.quantizers import BaseKerasInferableQuantizer
 from mct_quantizers.logger import Logger
 
 if FOUND_TF:
     import tensorflow as tf
     from keras.utils import tf_inspect
     from tensorflow_model_optimization.python.core.keras import utils
+    from mct_quantizers.keras.quantizers import BaseKerasInferableQuantizer
+
     keras = tf.keras
 
 

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
@@ -52,7 +52,7 @@ if FOUND_TF:
                                                                   threshold=threshold,
                                                                   signed=signed)
 
-            is_threshold_pot = np.all([int(np.log2(x)) == np.log2(x) for x in self.threshold.flatten()])
+            is_threshold_pot = np.all([int(np.log2(x)) == np.log2(x) for x in np.asarray(self.threshold).flatten()])
             assert is_threshold_pot, f'Expected threshold to be power of 2 but is {self.threshold}'
 
 else:

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -48,17 +48,19 @@ if FOUND_TF:
                 signed: whether or not to use signed quantization
             """
             assert isinstance(threshold, list), f'Expected threshold to be of type list but is {type(threshold)}'
+            # In activation per-channel quantization is not supported thus we expect a single min/max value.
+            assert len(threshold) == 1, f'In per-tensor quantization threshold should be of length 1 but is {len(threshold)}'
             assert all([isinstance(x, (float, np.float32, tf.float32)) for x in
                         threshold]), f'Expected threshold list to contain float or np.float values but found ' \
                                      f'{[type(x) for x in threshold]}'
 
-            self.threshold = np.asarray(threshold)
+            self.threshold = threshold
             self.signed = signed
 
-            delta = self.threshold / (2 ** (num_bits - int(self.signed)))
+            delta = self.threshold[0] / (2 ** (num_bits - int(self.signed)))
             # In activation quantization is per-tensor only - thus we pass the threshold as a list with a len of 1
-            min_range = list(-self.threshold) if self.signed else [0.0]
-            max_range = list(self.threshold - delta)
+            min_range = [-threshold[0]] if self.signed else [0.0]
+            max_range = [self.threshold[0] - delta]
 
             super(ActivationSymmetricInferableQuantizer, self).__init__(num_bits=num_bits,
                                                                         min_range=min_range,

--- a/tests/keras_tests/quantizers_tests/test_activation_inferable_quantizers.py
+++ b/tests/keras_tests/quantizers_tests/test_activation_inferable_quantizers.py
@@ -118,7 +118,7 @@ class TestKerasActivationInferableQuantizers(unittest.TestCase):
             ActivationPOTInferableQuantizer(num_bits=8,
                                             threshold=[3.],
                                             signed=True)
-        self.assertEqual('Expected threshold to be power of 2 but is [3.]', str(e.exception))
+        self.assertEqual('Expected threshold to be power of 2 but is [3.0]', str(e.exception))
 
     def test_power_of_two_activation_quantizer(self):
         thresholds = [1.]


### PR DESCRIPTION
Fix converting trainable quantizers to inferable quantizers in ActivationQuantizationHolder. The issue with the current status is that finalized models can not be saved and loaded since there are weights in the layer that no longer exist after converting to an inferable quantizer. This commit fixes this issue by creating a new layer from the configuration of the layer (after the trainable->inferable conversion).

Also, this commit fixes an issue with activation inferable quantizers that should receive a list of thresholds and not a numpy array.