### PR TITLE
Replace quantizer_type property in @mark_quantizer with "identifier" property

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ On top of `BaseInferableQuantizer` the library defines a set of framework-specif
 The [`@mark_quantizer`](mct_quantizers/common/base_inferable_quantizer.py) decorator is used to assign each quantizer with static properties that define its task compatibility. Each quantizer class should be decorated with this decorator, which defines the following properties:
  - [`QuantizationTarget`](mct_quantizers/common/base_inferable_quantizer.py): An Enum that indicates whether the quantizer is intended for weights or activations quantization.
  - [`QuantizationMethod`](mct_quantizers/common/quant_info.py): A list of quantization methods (Uniform, Symmetric, etc.).
- - `quantizer_type`: An optional property that defines the type of the quantization technique. This is a helper property that allows the creation of advanced quantizers for specific tasks.
+ - `identifier`: A unique identifier for the quantizer class. This is a helper property that allows the creation of advanced quantizers for specific tasks.
  
 ## Getting Started
 

--- a/mct_quantizers/common/base_inferable_quantizer.py
+++ b/mct_quantizers/common/base_inferable_quantizer.py
@@ -23,9 +23,13 @@ class QuantizationTarget(Enum):
     Weights = "Weights"
 
 
+class InferableQuantizerID(Enum):
+    INFERABLE = "inferable_quantizer_id"
+
+
 def mark_quantizer(quantization_target: QuantizationTarget = None,
                    quantization_method: List[QuantizationMethod] = None,
-                   quantizer_type: Any = None):
+                   identifier: Any = None):
     """
     A function to be used as decoration for all inferable quantizers (which inherit from BaseInferableQuantizer).
     By decorating a class with this decoration, we can define required static properties of the quantizer.
@@ -35,8 +39,8 @@ def mark_quantizer(quantization_target: QuantizationTarget = None,
             use the quantizer for.
         quantization_method: A list of QuantizationMethod values to indicate all type of quantization methods that the
             quantizer supports.
-        quantizer_type: The type of the quantizer (quantization technique).
-            This can differ, depending on the purpose the quantizer is for.
+        identifier: A unique identifier for the quantizer class (either the quantization
+            type/technique or other unique ID).
 
     Returns: A function that decorates a class object.
 
@@ -53,7 +57,7 @@ def mark_quantizer(quantization_target: QuantizationTarget = None,
         """
         quantizer_class_object.quantization_target = quantization_target
         quantizer_class_object.quantization_method = quantization_method
-        quantizer_class_object.quantizer_type = quantizer_type
+        quantizer_class_object.identifier = identifier
 
         return quantizer_class_object
 

--- a/mct_quantizers/common/base_inferable_quantizer.py
+++ b/mct_quantizers/common/base_inferable_quantizer.py
@@ -23,7 +23,7 @@ class QuantizationTarget(Enum):
     Weights = "Weights"
 
 
-class InferableQuantizerID(Enum):
+class QuantizerID(Enum):
     INFERABLE = "inferable_quantizer_id"
 
 

--- a/mct_quantizers/common/constants.py
+++ b/mct_quantizers/common/constants.py
@@ -47,7 +47,7 @@ ENABLE_ACTIVATION_QUANTIZATION = 'enable_activation_quantization'
 
 QUANTIZATION_TARGET = 'quantization_target'
 QUANTIZATION_METHOD = 'quantization_method'
-QUANTIZER_TYPE = 'quantizer_type'
+QUANTIZER_ID = 'identifier'
 
 # In KerasQuantizationWrapper and PytorchQuantizationWrapper multiple quantizers are kept
 ACTIVATION_QUANTIZERS = "activation_quantizers"

--- a/mct_quantizers/common/get_quantizers.py
+++ b/mct_quantizers/common/get_quantizers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import QUANTIZATION_TARGET, QUANTIZATION_METHOD, QUANTIZER_ID
 from mct_quantizers.common.get_all_subclasses import get_all_subclasses
 from mct_quantizers.common.quant_info import QuantizationMethod

--- a/mct_quantizers/common/get_quantizers.py
+++ b/mct_quantizers/common/get_quantizers.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget
-from mct_quantizers.common.constants import QUANTIZATION_TARGET, QUANTIZATION_METHOD, QUANTIZER_TYPE
+from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.constants import QUANTIZATION_TARGET, QUANTIZATION_METHOD, QUANTIZER_ID
 from mct_quantizers.common.get_all_subclasses import get_all_subclasses
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.logger import Logger
@@ -37,12 +37,11 @@ def get_inferable_quantizer_class(quant_target: QuantizationTarget,
 
     """
     qat_quantizer_classes = get_all_subclasses(quantizer_base_class)
-    # TODO: Need to update condition on QUANTIZER_TYPE once changing this field to 'identifier' and creating a unique
-    #  identifier for inferable quantizers (see  https://app.clickup.com/t/860r5jh2p)
+
     filtered_quantizers = list(filter(lambda q_class: getattr(q_class, QUANTIZATION_TARGET) == quant_target and
                                                       getattr(q_class, QUANTIZATION_METHOD) is not None and
                                                       quant_method in getattr(q_class, QUANTIZATION_METHOD) and
-                                                      getattr(q_class, QUANTIZER_TYPE) is None,
+                                                      getattr(q_class, QUANTIZER_ID) is InferableQuantizerId.INFERABLE,
                                       qat_quantizer_classes))
 
     if len(filtered_quantizers) != 1:

--- a/mct_quantizers/common/get_quantizers.py
+++ b/mct_quantizers/common/get_quantizers.py
@@ -41,7 +41,7 @@ def get_inferable_quantizer_class(quant_target: QuantizationTarget,
     filtered_quantizers = list(filter(lambda q_class: getattr(q_class, QUANTIZATION_TARGET) == quant_target and
                                                       getattr(q_class, QUANTIZATION_METHOD) is not None and
                                                       quant_method in getattr(q_class, QUANTIZATION_METHOD) and
-                                                      getattr(q_class, QUANTIZER_ID) is InferableQuantizerId.INFERABLE,
+                                                      getattr(q_class, QUANTIZER_ID) is QuantizerId.INFERABLE,
                                       qat_quantizer_classes))
 
     if len(filtered_quantizers) != 1:

--- a/mct_quantizers/common/get_quantizers.py
+++ b/mct_quantizers/common/get_quantizers.py
@@ -41,7 +41,7 @@ def get_inferable_quantizer_class(quant_target: QuantizationTarget,
     filtered_quantizers = list(filter(lambda q_class: getattr(q_class, QUANTIZATION_TARGET) == quant_target and
                                                       getattr(q_class, QUANTIZATION_METHOD) is not None and
                                                       quant_method in getattr(q_class, QUANTIZATION_METHOD) and
-                                                      getattr(q_class, QUANTIZER_ID) is QuantizerId.INFERABLE,
+                                                      getattr(q_class, QUANTIZER_ID) is QuantizerID.INFERABLE,
                                       qat_quantizer_classes))
 
     if len(filtered_quantizers) != 1:

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
@@ -17,7 +17,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TF, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.logger import Logger
@@ -30,7 +30,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.LUT_POT_QUANTIZER],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class ActivationLutPOTInferableQuantizer(BaseKerasInferableQuantizer):
         """
         Class for quantizing activations using lut power-of-two quantizer

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
@@ -17,7 +17,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TF, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.logger import Logger
@@ -30,7 +30,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.LUT_POT_QUANTIZER],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class ActivationLutPOTInferableQuantizer(BaseKerasInferableQuantizer):
         """
         Class for quantizing activations using lut power-of-two quantizer
@@ -154,6 +154,6 @@ if FOUND_TF:
 else:
     class ActivationLutPOTInferableQuantizer:  # pragma: no cover
         def __init__(self, *args, **kwargs):
-            Logger.error('Installing tensorflow and tensorflow_model_optimization is mandatory '
+            Logger.error('Installing tensorflow is mandatory '
                          'when using ActivationLutPOTInferableQuantizer. '
                          'Could not find Tensorflow package.')

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.logger import Logger
@@ -28,7 +28,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class ActivationPOTInferableQuantizer(ActivationSymmetricInferableQuantizer):
         """
         Class for quantizing activations using power-of-two quantizer
@@ -58,6 +58,6 @@ if FOUND_TF:
 else:
     class ActivationPOTInferableQuantizer:  # pragma: no cover
         def __init__(self, *args, **kwargs):
-            Logger.error('Installing tensorflow and tensorflow_model_optimization is mandatory '
+            Logger.error('Installing tensorflow is mandatory '
                          'when using ActivationPOTInferableQuantizer. '
                          'Could not find Tensorflow package.')

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.logger import Logger
@@ -28,7 +28,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class ActivationPOTInferableQuantizer(ActivationSymmetricInferableQuantizer):
         """
         Class for quantizing activations using power-of-two quantizer

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -28,7 +28,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class ActivationSymmetricInferableQuantizer(ActivationUniformInferableQuantizer):
 
         """

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -28,7 +28,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class ActivationSymmetricInferableQuantizer(ActivationUniformInferableQuantizer):
 
         """
@@ -81,6 +81,6 @@ if FOUND_TF:
 else:
     class ActivationSymmetricInferableQuantizer:  # pragma: no cover
         def __init__(self, *args, **kwargs):
-            raise Exception('Installing tensorflow and tensorflow_model_optimization is mandatory '
+            raise Exception('Installing tensorflow is mandatory '
                             'when using ActivationSymmetricInferableQuantizer. '
                             'Could not find Tensorflow package.')

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.common.quant_utils import adjust_range_to_include_zero
@@ -30,7 +30,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.UNIFORM],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class ActivationUniformInferableQuantizer(BaseKerasInferableQuantizer):
         """
         Class for quantizing activations using an uniform quantizer

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.common.quant_utils import adjust_range_to_include_zero
@@ -30,7 +30,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.UNIFORM],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class ActivationUniformInferableQuantizer(BaseKerasInferableQuantizer):
         """
         Class for quantizing activations using an uniform quantizer
@@ -106,6 +106,6 @@ if FOUND_TF:
 else:
     class ActivationUniformInferableQuantizer:  # pragma: no cover
         def __init__(self, *args, **kwargs):
-            Logger.error('Installing tensorflow and tensorflow_model_optimization is mandatory '
+            Logger.error('Installing tensorflow is mandatory '
                          'when using ActivationUniformInferableQuantizer. '
                          'Could not find Tensorflow package.')

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TF, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -28,7 +28,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.LUT_POT_QUANTIZER],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class WeightsLUTPOTInferableQuantizer(WeightsLUTSymmetricInferableQuantizer):
         """
         Class for quantizing weights using a lut power-of-two quantizer

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TF, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -28,7 +28,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.LUT_POT_QUANTIZER],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class WeightsLUTPOTInferableQuantizer(WeightsLUTSymmetricInferableQuantizer):
         """
         Class for quantizing weights using a lut power-of-two quantizer
@@ -73,6 +73,6 @@ if FOUND_TF:
 else:
     class WeightsLUTPOTInferableQuantizer:  # pragma: no cover
         def __init__(self, *args, **kwargs):
-            raise Exception('Installing tensorflow and tensorflow_model_optimization is mandatory '
+            raise Exception('Installing tensorflow is mandatory '
                             'when using WeightsLUTPOTInferableQuantizer. '
                             'Could not find Tensorflow package.')

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
@@ -17,7 +17,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer
+from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TF, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -30,7 +30,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.LUT_SYM_QUANTIZER],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class WeightsLUTSymmetricInferableQuantizer(BaseKerasInferableQuantizer):
         """
         Class for quantizing weights using a lut symmetric quantizer
@@ -182,6 +182,6 @@ if FOUND_TF:
 else:
     class WeightsLUTSymmetricInferableQuantizer:  # pragma: no cover
         def __init__(self, *args, **kwargs):
-            raise Exception('Installing tensorflow and tensorflow_model_optimization is mandatory '
+            raise Exception('Installing tensorflow is mandatory '
                             'when using WeightsLUTSymmetricInferableQuantizer. '
                             'Could not find Tensorflow package.')

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
@@ -17,7 +17,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer, QuantizerID
 from mct_quantizers.common.constants import FOUND_TF, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -30,7 +30,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.LUT_SYM_QUANTIZER],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class WeightsLUTSymmetricInferableQuantizer(BaseKerasInferableQuantizer):
         """
         Class for quantizing weights using a lut symmetric quantizer

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer, QuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -27,7 +27,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class WeightsPOTInferableQuantizer(WeightsSymmetricInferableQuantizer):
         """
         Class for quantizing weights using power-of-two quantizer

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer
+from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -27,7 +27,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class WeightsPOTInferableQuantizer(WeightsSymmetricInferableQuantizer):
         """
         Class for quantizing weights using power-of-two quantizer
@@ -63,6 +63,6 @@ if FOUND_TF:
 else:
     class WeightsPOTInferableQuantizer:  # pragma: no cover
         def __init__(self, *args, **kwargs):
-            raise Exception('Installing tensorflow and tensorflow_model_optimization is mandatory '
+            raise Exception('Installing tensorflow is mandatory '
                             'when using WeightsPOTInferableQuantizer. '
                             'Could not find Tensorflow package.')

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -27,7 +27,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class WeightsSymmetricInferableQuantizer(WeightsUniformInferableQuantizer):
         """
         Class for quantizing weights using a symmetric quantizer

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -27,7 +27,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class WeightsSymmetricInferableQuantizer(WeightsUniformInferableQuantizer):
         """
         Class for quantizing weights using a symmetric quantizer
@@ -82,6 +82,6 @@ if FOUND_TF:
 else:
     class WeightsSymmetricInferableQuantizer:  # pragma: no cover
         def __init__(self, *args, **kwargs):
-            raise Exception('Installing tensorflow and tensorflow_model_optimization is mandatory '
+            raise Exception('Installing tensorflow is mandatory '
                             'when using WeightsPOTInferableQuantizer. '
                             'Could not find Tensorflow package.')

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer, QuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.common.quant_utils import adjust_range_to_include_zero
@@ -30,7 +30,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.UNIFORM],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class WeightsUniformInferableQuantizer(BaseKerasInferableQuantizer):
         """
         Class for quantizing weights using a uniform quantizer

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -16,7 +16,7 @@ from typing import List
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer
+from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, mark_quantizer, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TF
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.common.quant_utils import adjust_range_to_include_zero
@@ -30,7 +30,7 @@ if FOUND_TF:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.UNIFORM],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class WeightsUniformInferableQuantizer(BaseKerasInferableQuantizer):
         """
         Class for quantizing weights using a uniform quantizer
@@ -161,6 +161,6 @@ if FOUND_TF:
 else:
     class WeightsUniformInferableQuantizer:  # pragma: no cover
         def __init__(self, *args, **kwargs):
-            raise Exception('Installing tensorflow and tensorflow_model_optimization is mandatory '
+            raise Exception('Installing tensorflow is mandatory '
                             'when using WeightsUniformInferableQuantizer. '
                             'Could not find Tensorflow package.')

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -26,7 +26,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.LUT_POT_QUANTIZER],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class ActivationLutPOTInferableQuantizer(BaseLUTSymmetricInferableQuantizer):
         """
         Class for quantizing activations using a lut power-of-two quantizer

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -26,7 +26,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.LUT_POT_QUANTIZER],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class ActivationLutPOTInferableQuantizer(BaseLUTSymmetricInferableQuantizer):
         """
         Class for quantizing activations using a lut power-of-two quantizer

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -26,7 +26,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class ActivationPOTInferableQuantizer(ActivationSymmetricInferableQuantizer):
         """
         Class for quantizing activations using power-of-two quantizer

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -26,7 +26,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class ActivationPOTInferableQuantizer(ActivationSymmetricInferableQuantizer):
         """
         Class for quantizing activations using power-of-two quantizer

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -25,7 +25,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class ActivationSymmetricInferableQuantizer(BaseSymmetricInferableQuantizer):
         """
         Class for quantizing activations using a symmetric quantizer

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -25,7 +25,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class ActivationSymmetricInferableQuantizer(BaseSymmetricInferableQuantizer):
         """
         Class for quantizing activations using a symmetric quantizer

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -25,7 +25,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.UNIFORM],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class ActivationUniformInferableQuantizer(BaseUniformInferableQuantizer):
         """
         Class for quantizing activations using an uniform quantizer

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -25,7 +25,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.UNIFORM],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class ActivationUniformInferableQuantizer(BaseUniformInferableQuantizer):
         """
         Class for quantizing activations using an uniform quantizer

--- a/mct_quantizers/pytorch/quantizers/base_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_lut_symmetric_inferable_quantizer.py
@@ -15,7 +15,7 @@
 import numpy as np
 import warnings
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -25,7 +25,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=None,
                     quantization_method=[QuantizationMethod.LUT_SYM_QUANTIZER],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class BaseLUTSymmetricInferableQuantizer(BasePyTorchInferableQuantizer):
 
         def __init__(self,

--- a/mct_quantizers/pytorch/quantizers/base_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_lut_symmetric_inferable_quantizer.py
@@ -15,7 +15,7 @@
 import numpy as np
 import warnings
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -25,7 +25,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=None,
                     quantization_method=[QuantizationMethod.LUT_SYM_QUANTIZER],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class BaseLUTSymmetricInferableQuantizer(BasePyTorchInferableQuantizer):
 
         def __init__(self,

--- a/mct_quantizers/pytorch/quantizers/base_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_symmetric_inferable_quantizer.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -24,7 +24,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=None,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class BaseSymmetricInferableQuantizer(BasePyTorchInferableQuantizer):
 
         def __init__(self,

--- a/mct_quantizers/pytorch/quantizers/base_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_symmetric_inferable_quantizer.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -24,7 +24,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=None,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class BaseSymmetricInferableQuantizer(BasePyTorchInferableQuantizer):
 
         def __init__(self,

--- a/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -24,7 +24,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=None,
                     quantization_method=[QuantizationMethod.UNIFORM],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class BaseUniformInferableQuantizer(BasePyTorchInferableQuantizer):
 
         def __init__(self,

--- a/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -24,7 +24,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=None,
                     quantization_method=[QuantizationMethod.UNIFORM],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class BaseUniformInferableQuantizer(BasePyTorchInferableQuantizer):
 
         def __init__(self,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -26,7 +26,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.LUT_POT_QUANTIZER],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class WeightsLUTPOTInferableQuantizer(WeightsLUTSymmetricInferableQuantizer):
         """
         Class for quantizing weights using lut power-of-two quantizer

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -26,7 +26,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.LUT_POT_QUANTIZER],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class WeightsLUTPOTInferableQuantizer(WeightsLUTSymmetricInferableQuantizer):
         """
         Class for quantizing weights using lut power-of-two quantizer

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -28,7 +28,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.LUT_SYM_QUANTIZER],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class WeightsLUTSymmetricInferableQuantizer(BaseLUTSymmetricInferableQuantizer):
         """
         Class for quantizing weights using a lut symmetric quantizer

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH, MULTIPLIER_N_BITS, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -28,7 +28,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.LUT_SYM_QUANTIZER],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class WeightsLUTSymmetricInferableQuantizer(BaseLUTSymmetricInferableQuantizer):
         """
         Class for quantizing weights using a lut symmetric quantizer

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -26,7 +26,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class WeightsPOTInferableQuantizer(WeightsSymmetricInferableQuantizer):
         """
         Class for quantizing weights using power-of-two quantizer

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -26,7 +26,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class WeightsPOTInferableQuantizer(WeightsSymmetricInferableQuantizer):
         """
         Class for quantizing weights using power-of-two quantizer

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -27,7 +27,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class WeightsSymmetricInferableQuantizer(BaseSymmetricInferableQuantizer):
         """
         Class for quantizing weights using a symmetric quantizer

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
@@ -27,7 +27,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class WeightsSymmetricInferableQuantizer(BaseSymmetricInferableQuantizer):
         """
         Class for quantizing weights using a symmetric quantizer

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.logger import Logger
@@ -27,7 +27,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.UNIFORM],
-                    quantizer_type=None)
+                    identifier=InferableQuantizerID.INFERABLE)
     class WeightsUniformInferableQuantizer(BaseUniformInferableQuantizer):
         """
         Class for quantizing weights using a uniform quantizer

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, InferableQuantizerID
+from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.logger import Logger
@@ -27,7 +27,7 @@ if FOUND_TORCH:
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.UNIFORM],
-                    identifier=InferableQuantizerID.INFERABLE)
+                    identifier=QuantizerID.INFERABLE)
     class WeightsUniformInferableQuantizer(BaseUniformInferableQuantizer):
         """
         Class for quantizing weights using a uniform quantizer


### PR DESCRIPTION
The new identifier property can be anything that separates the quantizer class from other quantizers.

In addition, update all properties of existing inferable quantizers with a unique InferableQuantizerID identifier to allow dynamic retrieval of inferable quantizers.

The purpose of this change is to allow a user of mct quantizers to define external quantizers that are based on the MCT Quantizers infrastructure, without causing conflicts with the internal inferable quantizers.

For more details see the task here: https://app.clickup.com/t/860r5jh2p