### PR TITLE
Add GitHub actions for extended tests

### DIFF
--- a/.github/workflows/run_keras_tests.yml
+++ b/.github/workflows/run_keras_tests.yml
@@ -1,0 +1,26 @@
+name: Run Keras Tests
+
+on:
+  workflow_call:
+    inputs:
+      tf-version:
+        required: true
+        type: string
+
+jobs:
+  run-tensorflow-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Python 3
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.10
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt          
+          pip install tensorflow==${{ inputs.tf-version }}
+      - name: Run unittests
+        run: |
+          python -m unittest discover tests/keras_tests -v

--- a/.github/workflows/run_pytorch_tests.yml
+++ b/.github/workflows/run_pytorch_tests.yml
@@ -1,0 +1,29 @@
+name: Run PyTorch Tests
+
+on:
+  workflow_call:
+    inputs:
+      torch-version:
+        required: true
+        type: string
+
+jobs:
+  run-pytorch-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Python 3
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.10
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt          
+          pip install torch==${{ inputs.torch-version }} torchvision
+      - name: Run unittests
+        run: python -m unittest discover tests/pytorch_tests -v
+
+
+
+

--- a/.github/workflows/run_tests_suite_pip.yml
+++ b/.github/workflows/run_tests_suite_pip.yml
@@ -26,8 +26,8 @@ jobs:
         run: |
           git checkout tags/${{  inputs.mct_quantizers_version  }}
           pip install -r requirements.txt
-          pip install tensorflow==2.11
-          pip install torch==1.13 torchvision
+          pip install tensorflow==2.12.*
+          pip install torch==1.13.* torchvision
       - name: Build WHL file
         run: |
           version=$(python -c 'import mct_quantizers; print(mct_quantizers.__version__)')

--- a/.github/workflows/run_tests_suite_python310.yml
+++ b/.github/workflows/run_tests_suite_python310.yml
@@ -1,4 +1,4 @@
-name: Python 3.9
+name: Python 3.10
 on:
   workflow_dispatch: # Allow manual triggers
   schedule:
@@ -18,12 +18,12 @@ jobs:
       - name: Install Python 3
         uses: actions/setup-python@v1
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install tensorflow==2.11.*
-          pip install torch
+          pip install tensorflow==2.12.*
+          pip install torch==1.13.*
       - name: Run unittests
         run: python -m unittest discover -s tests -v

--- a/.github/workflows/run_tests_suite_python39.yml
+++ b/.github/workflows/run_tests_suite_python39.yml
@@ -1,0 +1,29 @@
+name: Python 3.9
+on:
+  workflow_dispatch: # Allow manual triggers
+  schedule:
+    - cron: 0 0 * * *
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      COVERAGE_THRESHOlD: 80
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Python 3
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install tensorflow==2.12.*
+          pip install torch==1.13.*
+      - name: Run unittests
+        run: python -m unittest discover -s tests -v

--- a/.github/workflows/run_tests_tf211.yml
+++ b/.github/workflows/run_tests_tf211.yml
@@ -1,0 +1,11 @@
+name: Run Tests - Tensorflow 2.11
+on:
+  workflow_dispatch: # Allow manual triggers
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  run-tensorflow-2_11:
+    uses: ./.github/workflows/run_keras_tests.yml
+    with:
+      tf-version: "2.11.*"

--- a/.github/workflows/run_tests_tf212.yml
+++ b/.github/workflows/run_tests_tf212.yml
@@ -1,0 +1,11 @@
+name: Run Tests - Tensorflow 2.12
+on:
+  workflow_dispatch: # Allow manual triggers
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  run-tensorflow-2_12:
+    uses: ./.github/workflows/run_keras_tests.yml
+    with:
+      tf-version: "2.12.*"

--- a/.github/workflows/run_tests_torch1_12.yml
+++ b/.github/workflows/run_tests_torch1_12.yml
@@ -1,0 +1,11 @@
+name: Run Tests - PyTorch 1.12
+on:
+  workflow_dispatch: # Allow manual triggers
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  run-pytorch-1_13:
+    uses: ./.github/workflows/run_pytorch_tests.yml
+    with:
+      torch-version: "1.12.*"

--- a/.github/workflows/run_tests_torch1_13.yml
+++ b/.github/workflows/run_tests_torch1_13.yml
@@ -1,0 +1,11 @@
+name: Run Tests - PyTorch 1.13
+on:
+  workflow_dispatch: # Allow manual triggers
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  run-pytorch-1_13:
+    uses: ./.github/workflows/run_pytorch_tests.yml
+    with:
+      torch-version: "1.13.*"


### PR DESCRIPTION
- Dedicated Pytorch and TF tests for nightly run
- Python 3.10 tests
- Changed Python tests  to work with latest supported TF and Torch versions - 2.12 and 1.13, respectively.