### PR TITLE
Pytorch quantizers changes

### DIFF
--- a/.github/workflows/run_pytorch_tests.yml
+++ b/.github/workflows/run_pytorch_tests.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt          
-          pip install torch==${{ inputs.torch-version }} torchvision onnx onnxruntime onnx-extensions
+          pip install torch==${{ inputs.torch-version }} torchvision onnx onnxruntime onnxruntime-extensions
       - name: Run unittests
         run: python -m unittest discover tests/pytorch_tests -v
 

--- a/.github/workflows/run_pytorch_tests.yml
+++ b/.github/workflows/run_pytorch_tests.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt          
-          pip install torch==${{ inputs.torch-version }} torchvision
+          pip install torch==${{ inputs.torch-version }} torchvision onnx onnxruntime onnx-extensions
       - name: Run unittests
         run: python -m unittest discover tests/pytorch_tests -v
 

--- a/.github/workflows/run_tests_suite_python310.yml
+++ b/.github/workflows/run_tests_suite_python310.yml
@@ -24,6 +24,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install tensorflow==2.12.*
-          pip install torch==1.13.* onnx onnxruntime onnx-extensions
+          pip install torch==1.13.* onnx onnxruntime onnxruntime-extensions
       - name: Run unittests
         run: python -m unittest discover -s tests -v

--- a/.github/workflows/run_tests_suite_python310.yml
+++ b/.github/workflows/run_tests_suite_python310.yml
@@ -24,6 +24,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install tensorflow==2.12.*
-          pip install torch==1.13.*
+          pip install torch==1.13.* onnx onnxruntime onnx-extensions
       - name: Run unittests
         run: python -m unittest discover -s tests -v

--- a/.github/workflows/run_tests_suite_python39.yml
+++ b/.github/workflows/run_tests_suite_python39.yml
@@ -24,6 +24,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install tensorflow==2.12.*
-          pip install torch==1.13.* onnx onnxruntime onnx-extensions
+          pip install torch==1.13.* onnx onnxruntime onnxruntime-extensions
       - name: Run unittests
         run: python -m unittest discover -s tests -v

--- a/.github/workflows/run_tests_suite_python39.yml
+++ b/.github/workflows/run_tests_suite_python39.yml
@@ -24,6 +24,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install tensorflow==2.12.*
-          pip install torch==1.13.*
+          pip install torch==1.13.* onnx onnxruntime onnx-extensions
       - name: Run unittests
         run: python -m unittest discover -s tests -v

--- a/mct_quantizers/__init__.py
+++ b/mct_quantizers/__init__.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+__version__ = "1.2.0"
+
+
 from mct_quantizers.common.base_inferable_quantizer import QuantizationTarget, BaseInferableQuantizer, mark_quantizer
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.keras.activation_quantization_holder import KerasActivationQuantizationHolder
@@ -28,4 +31,4 @@ from mct_quantizers.pytorch import quantizers as pytorch_quantizers
 
 from mct_quantizers.pytorch.onnxruntime_session_options import get_ort_session_options
 
-__version__ = "1.2.0"
+

--- a/mct_quantizers/__init__.py
+++ b/mct_quantizers/__init__.py
@@ -26,4 +26,6 @@ from mct_quantizers.common import constants
 from mct_quantizers.keras import quantizers as keras_quantizers
 from mct_quantizers.pytorch import quantizers as pytorch_quantizers
 
+from mct_quantizers.pytorch.onnxruntime_session_options import get_ort_session_options
+
 __version__ = "1.2.0"

--- a/mct_quantizers/common/constants.py
+++ b/mct_quantizers/common/constants.py
@@ -20,12 +20,18 @@ import importlib.util
 
 TENSORFLOW = 'tensorflow'
 TORCH = 'torch'
+ONNX = 'onnx'
+ONNXRUNTIME = 'onnxruntime'
+ONNXRUNTIME_EXTENSIONS = 'onnxruntime_extensions'
+
 FOUND_TF = importlib.util.find_spec(TENSORFLOW) is not None
 FOUND_TORCH = importlib.util.find_spec(TORCH) is not None
+FOUND_ONNX = importlib.util.find_spec(ONNX) is not None
+FOUND_ONNXRUNTIME = importlib.util.find_spec(ONNXRUNTIME) is not None
+FOUND_ONNXRUNTIME_EXTENSIONS = importlib.util.find_spec(ONNXRUNTIME_EXTENSIONS) is not None
 
 
 ## Quantization properties
-
 IS_WEIGHTS = "is_weights"
 IS_ACTIVATIONS = "is_activations"
 WEIGHTS_QUANTIZERS = "weights_quantizer"

--- a/mct_quantizers/common/constants.py
+++ b/mct_quantizers/common/constants.py
@@ -22,7 +22,7 @@ TENSORFLOW = 'tensorflow'
 TORCH = 'torch'
 ONNX = 'onnx'
 ONNXRUNTIME = 'onnxruntime'
-ONNXRUNTIME_EXTENSIONS = 'onnxruntime-extensions'
+ONNXRUNTIME_EXTENSIONS = 'onnxruntime_extensions'
 
 FOUND_TF = importlib.util.find_spec(TENSORFLOW) is not None
 FOUND_TORCH = importlib.util.find_spec(TORCH) is not None

--- a/mct_quantizers/common/constants.py
+++ b/mct_quantizers/common/constants.py
@@ -22,7 +22,7 @@ TENSORFLOW = 'tensorflow'
 TORCH = 'torch'
 ONNX = 'onnx'
 ONNXRUNTIME = 'onnxruntime'
-ONNXRUNTIME_EXTENSIONS = 'onnxruntime_extensions'
+ONNXRUNTIME_EXTENSIONS = 'onnxruntime-extensions'
 
 FOUND_TF = importlib.util.find_spec(TENSORFLOW) is not None
 FOUND_TORCH = importlib.util.find_spec(TORCH) is not None

--- a/mct_quantizers/pytorch/constants.py
+++ b/mct_quantizers/pytorch/constants.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+ONNX_CUSTOM_OP_DOMAIN = "mct_quantizers"

--- a/mct_quantizers/pytorch/onnxruntime_session_options.py
+++ b/mct_quantizers/pytorch/onnxruntime_session_options.py
@@ -2,7 +2,11 @@ import onnxruntime as ort
 from onnxruntime_extensions import get_library_path
 
 
-def get_ort_session_options():
+def get_ort_session_options() -> ort.SessionOptions:
+    """
+    :return: Session options for loading onnxruntime inference session with custom implementation
+    of onnx ops.
+    """
     opt = ort.SessionOptions()
     opt.register_custom_ops_library(get_library_path())
     return opt

--- a/mct_quantizers/pytorch/onnxruntime_session_options.py
+++ b/mct_quantizers/pytorch/onnxruntime_session_options.py
@@ -1,12 +1,36 @@
-import onnxruntime as ort
-from onnxruntime_extensions import get_library_path
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
+from mct_quantizers.common.constants import FOUND_ONNXRUNTIME, FOUND_ONNXRUNTIME_EXTENSIONS
 
-def get_ort_session_options() -> ort.SessionOptions:
-    """
-    :return: Session options for loading onnxruntime inference session with custom implementation
-    of onnx ops.
-    """
-    opt = ort.SessionOptions()
-    opt.register_custom_ops_library(get_library_path())
-    return opt
+if FOUND_ONNXRUNTIME and FOUND_ONNXRUNTIME_EXTENSIONS:
+    import onnxruntime as ort
+    from onnxruntime_extensions import get_library_path
+
+    def get_ort_session_options() -> ort.SessionOptions:
+        """
+        :return: Session options for loading onnxruntime inference
+        session with custom implementation of onnx ops.
+        """
+        opt = ort.SessionOptions()
+        opt.register_custom_ops_library(get_library_path())
+        return opt
+
+else:
+    def get_ort_session_options():
+        raise Exception('Installing onnxruntime onnxruntime-extensions and is mandatory '
+                        'when using get_ort_session_options. '
+                        'Could not find a package.')
+

--- a/mct_quantizers/pytorch/onnxruntime_session_options.py
+++ b/mct_quantizers/pytorch/onnxruntime_session_options.py
@@ -21,8 +21,8 @@ if FOUND_ONNXRUNTIME and FOUND_ONNXRUNTIME_EXTENSIONS:
 
     def get_ort_session_options() -> ort.SessionOptions:
         """
-        :return: Session options for loading onnxruntime inference
-        session with custom implementation of onnx ops.
+        Returns: Session options for loading onnxruntime inference session
+         with custom implementation of onnx ops.
         """
         opt = ort.SessionOptions()
         opt.register_custom_ops_library(get_library_path())

--- a/mct_quantizers/pytorch/onnxruntime_session_options.py
+++ b/mct_quantizers/pytorch/onnxruntime_session_options.py
@@ -1,0 +1,8 @@
+import onnxruntime as ort
+from onnxruntime_extensions import get_library_path
+
+
+def get_ort_session_options():
+    opt = ort.SessionOptions()
+    opt.register_custom_ops_library(get_library_path())
+    return opt

--- a/mct_quantizers/pytorch/quantizers/__init__.py
+++ b/mct_quantizers/pytorch/quantizers/__init__.py
@@ -21,7 +21,6 @@ from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activatio
     ActivationSymmetricInferableQuantizer
 from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_uniform_inferable_quantizer import \
     ActivationUniformInferableQuantizer
-from mct_quantizers.pytorch.quantizers.base_pytorch_inferable_quantizer import BasePyTorchInferableQuantizer
 from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_pot_inferable_quantizer import \
     WeightsLUTPOTInferableQuantizer
 from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_symmetric_inferable_quantizer import \

--- a/mct_quantizers/pytorch/quantizers/__init__.py
+++ b/mct_quantizers/pytorch/quantizers/__init__.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from mct_quantizers.pytorch.quantizers.base_pytorch_inferable_quantizer import BasePyTorchInferableQuantizer
-
 from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_lut_pot_inferable_quantizer import \
     ActivationLutPOTInferableQuantizer
 from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_pot_inferable_quantizer import \
@@ -23,7 +21,7 @@ from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activatio
     ActivationSymmetricInferableQuantizer
 from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_uniform_inferable_quantizer import \
     ActivationUniformInferableQuantizer
-
+from mct_quantizers.pytorch.quantizers.base_pytorch_inferable_quantizer import BasePyTorchInferableQuantizer
 from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_pot_inferable_quantizer import \
     WeightsLUTPOTInferableQuantizer
 from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_symmetric_inferable_quantizer import \

--- a/mct_quantizers/pytorch/quantizers/__init__.py
+++ b/mct_quantizers/pytorch/quantizers/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from mct_quantizers.pytorch.quantizers.base_pytorch_inferable_quantizer import BasePyTorchInferableQuantizer
+
 from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_lut_pot_inferable_quantizer import \
     ActivationLutPOTInferableQuantizer
 from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_pot_inferable_quantizer import \
@@ -21,7 +23,7 @@ from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activatio
     ActivationSymmetricInferableQuantizer
 from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_uniform_inferable_quantizer import \
     ActivationUniformInferableQuantizer
-from mct_quantizers.pytorch.quantizers.base_pytorch_inferable_quantizer import BasePyTorchInferableQuantizer
+
 from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_pot_inferable_quantizer import \
     WeightsLUTPOTInferableQuantizer
 from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_symmetric_inferable_quantizer import \

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
@@ -18,6 +18,7 @@ from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, Quant
 from mct_quantizers.common.constants import FOUND_TORCH, LUT_VALUES_BITWIDTH, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
+
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.base_lut_symmetric_inferable_quantizer import BaseLUTSymmetricInferableQuantizer

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
@@ -18,11 +18,12 @@ from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, Quant
 from mct_quantizers.common.constants import FOUND_TORCH, LUT_VALUES_BITWIDTH, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-
 if FOUND_TORCH:
     import torch
-    from mct_quantizers.pytorch.quantizers.base_lut_symmetric_inferable_quantizer import BaseLUTSymmetricInferableQuantizer
+    from mct_quantizers.pytorch.quantizers.base_lut_symmetric_inferable_quantizer import \
+        BaseLUTSymmetricInferableQuantizer
     from mct_quantizers.pytorch.quantizer_utils import to_torch_tensor, get_working_device, lut_quantizer
+
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.LUT_POT_QUANTIZER],

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
@@ -18,7 +18,6 @@ from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, Quant
 from mct_quantizers.common.constants import FOUND_TORCH, LUT_VALUES_BITWIDTH, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.base_lut_symmetric_inferable_quantizer import BaseLUTSymmetricInferableQuantizer

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
@@ -26,7 +26,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
 
     # Add onnx op function to use during onnxruntime ActivationPOTQuantizer op inference
-    @onnx_op(op_type="ActivationPOTQuantizer",
+    @onnx_op(op_type="mct_quantizers::ActivationPOTQuantizer",
              inputs=[PyCustomOpDef.dt_float],
              outputs=[PyCustomOpDef.dt_float],
              attrs={"threshold": PyCustomOpDef.dt_float,
@@ -125,7 +125,7 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
-            return g.op("ai.onnx.contrib::ActivationPOTQuantizer",
+            return g.op("mct_quantizers::ActivationPOTQuantizer",
                         input_tensor,
                         threshold_f=threshold,
                         signed_i=int(signed),

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
@@ -15,7 +15,6 @@
 from typing import Any, List
 
 import numpy as np
-from torch.onnx import symbolic_helper
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTENSIONS
@@ -24,8 +23,10 @@ from mct_quantizers.common.quant_info import QuantizationMethod
 if FOUND_TORCH:
     from mct_quantizers.pytorch.constants import ONNX_CUSTOM_OP_DOMAIN
     import torch
-    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_symmetric_inferable_quantizer import \
-    ActivationSymmetricInferableQuantizer, quantize_sym_activations_torch, quantize_sym_activations_numpy
+    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_symmetric_inferable_quantizer \
+        import \
+        ActivationSymmetricInferableQuantizer, quantize_sym_activations_torch, quantize_sym_activations_numpy
+
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],
@@ -65,14 +66,13 @@ if FOUND_TORCH:
             return super(ActivationPOTInferableQuantizer, self).__call__(inputs)
 
 
-
-
     class ActivationPOTF(torch.autograd.Function):
         """
         Custom autograd function for POT activations quantizer.
         It provides a way to define a custom forward and symbolic operation
         and currently does not implement a backward operation.
         """
+
         @staticmethod
         def forward(ctx, input_tensor, threshold, signed, num_bits):
             """
@@ -132,10 +132,12 @@ else:
                             'when using ActivationPOTInferableQuantizer. '
                             'Could not find torch package.')
 
-
 if FOUND_ONNXRUNTIME_EXTENSIONS:
-    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_symmetric_inferable_quantizer import quantize_sym_activations_numpy
+    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_symmetric_inferable_quantizer \
+        import \
+        quantize_sym_activations_numpy
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
+
 
     # Add onnx op function to use during onnxruntime ActivationPOTQuantizer op inference
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::ActivationPOTQuantizer",
@@ -152,6 +154,3 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
                                               kwargs["signed"],
                                               kwargs["num_bits"]
                                               )
-
-
-

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
@@ -23,11 +23,8 @@ from mct_quantizers.common.quant_info import QuantizationMethod
 if FOUND_TORCH:
     from mct_quantizers.pytorch.constants import ONNX_CUSTOM_OP_DOMAIN
     import torch
-    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_symmetric_inferable_quantizer import ActivationSymmetricInferableQuantizer, quantize_sym_activations_torch, quantize_sym_activations_numpy
-    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.base_activation_quantizer_autograd_function \
-        import \
-        BaseActivationQuantizerAutogradFunction
-
+    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_symmetric_inferable_quantizer import ActivationSymmetricInferableQuantizer, quantize_sym_activations_torch
+    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.base_activation_quantizer_autograd_function import BaseActivationQuantizerAutogradFunction
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
@@ -17,14 +17,11 @@ from typing import Any, List
 import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
-from mct_quantizers.common.constants import FOUND_TORCH
+from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTENSIONS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-if FOUND_TORCH:
-    import torch
-    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_symmetric_inferable_quantizer import ActivationSymmetricInferableQuantizer, quantize_sym_activations_numpy, quantize_sym_activations_torch
+if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
-
     # Add onnx op function to use during onnxruntime ActivationPOTQuantizer op inference
     @onnx_op(op_type="ActivationPOTQuantizer",
              inputs=[PyCustomOpDef.dt_float,
@@ -41,6 +38,9 @@ if FOUND_TORCH:
                                               signed,
                                               nbits)
 
+if FOUND_TORCH:
+    import torch
+    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_symmetric_inferable_quantizer import ActivationSymmetricInferableQuantizer, quantize_sym_activations_numpy, quantize_sym_activations_torch
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
@@ -56,6 +56,16 @@ if FOUND_TORCH:
             assert is_threshold_pot, f'Expected threshold to be power of 2 but is {threshold}'
 
         def __call__(self, inputs):
+            """
+            Quantize an input tensor. If custom implementation is enabled, quantizer's autograd
+            function class is applied.
+
+            Args:
+                inputs: Activation tensor to quantize.
+
+            Returns:
+                Quantized tensor.
+            """
             if self._use_custom_impl and torch.jit.is_tracing():
                 return ActivationPOTF.apply(inputs,
                                             self.threshold_np,
@@ -123,11 +133,11 @@ else:
                             'Could not find torch package.')
 
 if FOUND_ONNXRUNTIME_EXTENSIONS:
-    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_symmetric_inferable_quantizer \
-        import quantize_sym_activations_numpy
+    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_symmetric_inferable_quantizer import quantize_sym_activations_numpy
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
 
-    # Add onnx op function to use during onnxruntime ActivationPOTQuantizer op inference
+    # Add onnx op function to use during onnxruntime ActivationPOTQuantizer op inference.
+    # Using this decorator the op ActivationPOTQuantizer is defined using its inputs, outputs and attributes.
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::ActivationPOTQuantizer",
              inputs=[PyCustomOpDef.dt_float],
              outputs=[PyCustomOpDef.dt_float],

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_pot_inferable_quantizer.py
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, List
+from typing import List
 
 import numpy as np
 
-from mct_quantizers import __version__ as mctq_version
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTENSIONS
 from mct_quantizers.common.quant_info import QuantizationMethod
-from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.base_activation_quantizer_autograd_function \
-    import \
-    BaseActivationQuantizerAutogradFunction
 
 if FOUND_TORCH:
     from mct_quantizers.pytorch.constants import ONNX_CUSTOM_OP_DOMAIN
     import torch
     from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activation_symmetric_inferable_quantizer import ActivationSymmetricInferableQuantizer, quantize_sym_activations_torch, quantize_sym_activations_numpy
+    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.base_activation_quantizer_autograd_function \
+        import \
+        BaseActivationQuantizerAutogradFunction
+
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, List
+from typing import List
 
 import numpy as np
 

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -24,6 +24,9 @@ if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.base_symmetric_inferable_quantizer import BaseSymmetricInferableQuantizer
     from mct_quantizers.pytorch.constants import ONNX_CUSTOM_OP_DOMAIN
+    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers\
+        .base_activation_quantizer_autograd_function import \
+        BaseActivationQuantizerAutogradFunction
 
 
     def quantize_sym_activations_torch(input_tensor: torch.Tensor,
@@ -114,7 +117,7 @@ if FOUND_TORCH:
                                                                  quant_max=self.max_quantized_domain)
 
 
-    class ActivationSymF(torch.autograd.Function):
+    class ActivationSymF(BaseActivationQuantizerAutogradFunction):
         """
         Custom autograd function for Symmetric activations quantizer.
         It provides a way to define a custom forward and symbolic operation
@@ -157,20 +160,11 @@ if FOUND_TORCH:
             return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::ActivationSymmetricQuantizer", input_tensor,
                         threshold_f=threshold,
                         signed_i=int(signed),
-                        num_bits_i=num_bits
+                        num_bits_i=num_bits,
+                        **ActivationSymF._get_metadata_attributes()
                         ).setType(
                 input_tensor.type())
 
-        def backward(ctx: Any, *grad_outputs: Any) -> Any:
-            """
-            Backward computation function. Raises a NotImplementedError
-            since backward is not needed for this op.
-
-            Args:
-                ctx (Any): A context object from the forward pass.
-                grad_outputs (Any): Gradients w.r.t. the output tensor.
-            """
-            raise NotImplementedError()
 
 else:
     class ActivationSymmetricInferableQuantizer:  # pragma: no cover

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -154,7 +154,7 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
-            return g.op("mct_quantizers::ActivationSymmetricQuantizer", input_tensor,
+            return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::ActivationSymmetricQuantizer", input_tensor,
                         threshold_f=threshold,
                         signed_i=int(signed),
                         num_bits_i=num_bits

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -110,8 +110,7 @@ if FOUND_TORCH:
         def __init__(self,
                      num_bits: int,
                      threshold: List[float],
-                     signed: bool,
-                     use_custom_impl=False):
+                     signed: bool):
             """
             Initialize the quantizer with the specified parameters.
 
@@ -125,8 +124,6 @@ if FOUND_TORCH:
                 num_bits=num_bits,
                 threshold=threshold,
                 signed=signed)
-
-            self.use_custom_impl = use_custom_impl
 
             assert self.threshold_np.shape[0] == 1
             self.threshold_np = self.threshold_np[0]
@@ -149,7 +146,7 @@ if FOUND_TORCH:
             Returns:
                 quantized tensor.
             """
-            if self.use_custom_impl and torch.jit.is_tracing():
+            if self._use_custom_impl and torch.jit.is_tracing():
                 return ActivationSymF.apply(inputs,
                                             self.threshold_np,
                                             self.signed,

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -20,12 +20,11 @@ from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, Quant
 from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTENSIONS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-
-
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.base_symmetric_inferable_quantizer import BaseSymmetricInferableQuantizer
     from mct_quantizers.pytorch.constants import ONNX_CUSTOM_OP_DOMAIN
+
 
     def quantize_sym_activations_torch(input_tensor: torch.Tensor,
                                        threshold: float,
@@ -180,9 +179,9 @@ else:
                             'when using ActivationSymmetricInferableQuantizer. '
                             'Could not find torch package.')
 
-
 if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
+
 
     # Add onnx op function to use during onnxruntime ActivationSymmetricQuantizer op inference
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::ActivationSymmetricQuantizer",

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -17,12 +17,11 @@ from typing import Any, List
 import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
-from mct_quantizers.common.constants import FOUND_TORCH
+from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTENSIONS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-if FOUND_TORCH:
-    import torch
-    from mct_quantizers.pytorch.quantizers.base_symmetric_inferable_quantizer import BaseSymmetricInferableQuantizer
+
+if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
 
     # Add onnx op function to use during onnxruntime ActivationSymmetricQuantizer op inference
@@ -69,6 +68,9 @@ if FOUND_TORCH:
         quantized = np.round(np.clip(input_tensor, min, max) / scale) * scale
         return quantized
 
+if FOUND_TORCH:
+    import torch
+    from mct_quantizers.pytorch.quantizers.base_symmetric_inferable_quantizer import BaseSymmetricInferableQuantizer
 
     def quantize_sym_activations_torch(input_tensor: torch.Tensor,
                                        threshold: float,

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -24,10 +24,7 @@ if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.base_symmetric_inferable_quantizer import BaseSymmetricInferableQuantizer
     from mct_quantizers.pytorch.constants import ONNX_CUSTOM_OP_DOMAIN
-    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers\
-        .base_activation_quantizer_autograd_function import \
-        BaseActivationQuantizerAutogradFunction
-
+    from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.base_activation_quantizer_autograd_function import BaseActivationQuantizerAutogradFunction
 
     def quantize_sym_activations_torch(input_tensor: torch.Tensor,
                                        threshold: float,
@@ -173,11 +170,12 @@ else:
                             'when using ActivationSymmetricInferableQuantizer. '
                             'Could not find torch package.')
 
+
 if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
 
-
     # Add onnx op function to use during onnxruntime ActivationSymmetricQuantizer op inference
+    # Using this decorator the op ActivationSymmetricQuantizer is defined using its inputs, outputs and attributes.
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::ActivationSymmetricQuantizer",
              inputs=[PyCustomOpDef.dt_float],
              outputs=[PyCustomOpDef.dt_float],

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -23,25 +23,42 @@ from mct_quantizers.common.quant_info import QuantizationMethod
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.base_symmetric_inferable_quantizer import BaseSymmetricInferableQuantizer
-
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
 
-
+    # Add onnx op function to use during onnxruntime ActivationSymmetricQuantizer op inference
     @onnx_op(op_type="ActivationSymmetricQuantizer",
-             inputs=[PyCustomOpDef.dt_float, PyCustomOpDef.dt_float,
-                     PyCustomOpDef.dt_bool, PyCustomOpDef.dt_int64],
+             inputs=[PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_bool,
+                     PyCustomOpDef.dt_int64],
              outputs=[PyCustomOpDef.dt_float])
-    def activation_sym_ort(input_tensor: np.ndarray,
-                           threshold: float,
-                           signed: bool,
-                           num_bits: int):
-        return quantize_sym_activations_numpy(input_tensor, threshold, signed, num_bits)
+    def activation_sym_ort(input_tensor,
+                           threshold,
+                           signed,
+                           num_bits):
+        return quantize_sym_activations_numpy(input_tensor,
+                                              threshold,
+                                              signed,
+                                              num_bits)
 
 
     def quantize_sym_activations_numpy(input_tensor: np.ndarray,
                                        threshold: float,
                                        signed: bool,
                                        num_bits: int):
+        """
+           Quantizes the input tensor symmetrically using numpy.
+
+           Args:
+               input_tensor (np.ndarray): The input tensor to be quantized.
+               threshold (float): The quantization threshold.
+               signed (bool): A flag indicating whether the quantization is signed or unsigned.
+               num_bits (int): Number of bits to represent the quantized value.
+
+           Returns:
+               np.ndarray: Symmetrically quantized tensor.
+        """
+
         if signed:
             scale = threshold / (2 ** (num_bits - 1))
             min, max = -threshold, threshold - scale
@@ -57,6 +74,18 @@ if FOUND_TORCH:
                                        threshold: float,
                                        signed: bool,
                                        num_bits: int):
+        """
+        Quantizes the input tensor symmetrically using PyTorch.
+
+        Args:
+            input_tensor (torch.Tensor): The input tensor to be quantized.
+            threshold (float): The quantization threshold.
+            signed (bool): A flag indicating whether the quantization is signed or unsigned.
+            num_bits (int): Number of bits to represent the quantized value.
+
+        Returns:
+            torch.Tensor: Symmetrically quantized tensor.
+        """
         if signed:
             scale = threshold / (2 ** (num_bits - 1))
             min, max = -threshold, threshold - scale
@@ -133,13 +162,45 @@ if FOUND_TORCH:
 
 
     class ActivationSymF(torch.autograd.Function):
+        """
+        Custom autograd function for Symmetric activations quantizer.
+        It provides a way to define a custom forward and symbolic operation
+        and currently does not implement a backward operation.
+        """
 
         @staticmethod
         def forward(ctx, input_tensor, threshold, signed, num_bits):
+            """
+             Forward computation function. This method performs the forward computation using
+             the given quantize_sym_activations_torch function.
+
+             Args:
+                 ctx: An object that can be used to stash information for backward function.
+                 input_tensor: The input tensor to be quantized.
+                 threshold: The quantization threshold.
+                 signed: A flag that indicates if the quantization is signed or unsigned.
+                 num_bits: The number of bits to represent the quantized tensor.
+
+             Returns:
+                 The quantized tensor.
+             """
             return quantize_sym_activations_torch(input_tensor, threshold, signed, num_bits)
 
         @staticmethod
         def symbolic(g, input_tensor, threshold, signed, num_bits):
+            """
+            Symbolic method that defines the custom operation for ONNX export.
+
+            Args:
+                g: A graph object that represents the ONNX computation graph.
+                input_tensor: The input tensor to be quantized.
+                threshold: The quantization threshold.
+                signed: A flag that indicates if the quantization is signed or unsigned.
+                num_bits: The number of bits to represent the quantized value.
+
+            Returns:
+                The node in the ONNX graph representing the output of this operation.
+            """
             return g.op("ai.onnx.contrib::ActivationSymmetricQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
                         g.op('Constant', value_t=torch.tensor(signed, dtype=torch.bool)),
@@ -147,6 +208,14 @@ if FOUND_TORCH:
                 input_tensor.type())
 
         def backward(ctx: Any, *grad_outputs: Any) -> Any:
+            """
+            Backward computation function. Raises a NotImplementedError
+            since backward is not needed for this op.
+
+            Args:
+                ctx (Any): A context object from the forward pass.
+                grad_outputs (Any): Gradients w.r.t. the output tensor.
+            """
             raise NotImplementedError()
 
 else:

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -25,7 +25,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
 
     # Add onnx op function to use during onnxruntime ActivationSymmetricQuantizer op inference
-    @onnx_op(op_type="ActivationSymmetricQuantizer",
+    @onnx_op(op_type="mct_quantizers::ActivationSymmetricQuantizer",
              inputs=[PyCustomOpDef.dt_float],
              outputs=[PyCustomOpDef.dt_float],
              attrs={"threshold": PyCustomOpDef.dt_float,
@@ -200,7 +200,7 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
-            return g.op("ai.onnx.contrib::ActivationSymmetricQuantizer", input_tensor,
+            return g.op("mct_quantizers::ActivationSymmetricQuantizer", input_tensor,
                         threshold_f=threshold,
                         signed_i=int(signed),
                         num_bits_i=num_bits

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -122,8 +122,7 @@ if FOUND_TORCH:
         def __init__(self,
                      num_bits: int,
                      min_range: np.ndarray,
-                     max_range: np.ndarray,
-                     use_custom_impl: bool = False
+                     max_range: np.ndarray
                      ):
             """
             Initialize the quantizer with the specified parameters.
@@ -135,8 +134,7 @@ if FOUND_TORCH:
             """
             super(ActivationUniformInferableQuantizer, self).__init__(num_bits=num_bits,
                                                                       min_range=min_range,
-                                                                      max_range=max_range,
-                                                                      use_custom_impl=use_custom_impl)
+                                                                      max_range=max_range)
 
             assert isinstance(min_range,list), f'min_range is expected to be a list, but is of type {type(min_range)}'
             assert isinstance(max_range,list), f'max_range is expected to be a list, but is of type {type(max_range)}'
@@ -172,7 +170,7 @@ if FOUND_TORCH:
             Returns:
                 quantized tensor.
             """
-            if self.use_custom_impl and torch.jit.is_tracing():
+            if self._use_custom_impl and torch.jit.is_tracing():
                 return ActivationUniformF.apply(inputs, self.min_range, self.max_range, self.num_bits)
             else:
                 with torch.no_grad():

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import List
 
 import numpy as np
 
@@ -75,8 +76,8 @@ if FOUND_TORCH:
 
         def __init__(self,
                      num_bits: int,
-                     min_range: np.ndarray,
-                     max_range: np.ndarray
+                     min_range: List[float],
+                     max_range: List[float]
                      ):
             """
             Initialize the quantizer with the specified parameters.

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -12,15 +12,87 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import Any
+
 import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
+from mct_quantizers.common.quant_utils import adjust_range_to_include_zero
+from mct_quantizers.pytorch.quantizer_utils import fix_range_to_include_zero
 
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.base_uniform_inferable_quantizer import BaseUniformInferableQuantizer
+
+    from onnxruntime_extensions import onnx_op, PyCustomOpDef
+
+
+    @onnx_op(op_type="ActivationUniformQuantizer",
+             inputs=[PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_int64],
+             outputs=[PyCustomOpDef.dt_float])
+    def activation_uniform_ort(input_tensor: np.ndarray,
+                               min_range: float,
+                               max_range: float,
+                               num_bits: int):
+        return quantize_uniform_activations_numpy(input_tensor, min_range, max_range, num_bits)
+
+
+    def quantize_uniform_activations_torch(tensor_data: torch.Tensor,
+                                           range_min: float,
+                                           range_max: float,
+                                           n_bits: int) -> np.ndarray:
+
+        range_min = torch.tensor([range_min])
+        range_max = torch.tensor([range_max])
+
+        # adjusts the quantization rage so the quantization grid include zero.
+        a, b = fix_range_to_include_zero(range_min, range_max, n_bits)
+
+        # Compute the step size of quantized values.
+        delta = (b - a) / (2 ** n_bits - 1)
+
+        # Clip data in range
+        clipped_tensor = torch.clip(tensor_data, min=a, max=b)
+
+        # Quantize the data between min/max of quantization range.
+        q = delta * torch.round((clipped_tensor - a) / delta) + a
+        return q
+
+
+    def quantize_uniform_activations_numpy(tensor_data: np.ndarray,
+                                           range_min: float,
+                                           range_max: float,
+                                           n_bits: int) -> np.ndarray:
+        """
+        Quantize a tensor according to given range (min, max) and number of bits.
+
+        Args:
+            tensor_data: Tensor values to quantize.
+            range_min: minimum bound of the range for quantization (or array of min values per channel).
+            range_max: maximum bound of the range for quantization (or array of max values per channel).
+            n_bits: Number of bits to quantize the tensor.
+
+        Returns:
+            Quantized data.
+        """
+
+        # adjusts the quantization rage so the quantization grid include zero.
+        a, b = adjust_range_to_include_zero(range_min, range_max, n_bits)
+
+        # Compute the step size of quantized values.
+        delta = (b - a) / (2 ** n_bits - 1)
+
+        # Clip data in range
+        clipped_tensor = np.clip(tensor_data, a_min=a, a_max=b)
+
+        # Quantize the data between min/max of quantization range.
+        q = delta * np.round((clipped_tensor - a) / delta) + a
+        return q
 
 
     @mark_quantizer(quantization_target=QuantizationTarget.Activation,
@@ -35,6 +107,7 @@ if FOUND_TORCH:
                      num_bits: int,
                      min_range: np.ndarray,
                      max_range: np.ndarray,
+                     use_custom_impl: bool = False
                      ):
             """
             Initialize the quantizer with the specified parameters.
@@ -46,14 +119,16 @@ if FOUND_TORCH:
             """
             super(ActivationUniformInferableQuantizer, self).__init__(num_bits=num_bits,
                                                                       min_range=min_range,
-                                                                      max_range=max_range)
+                                                                      max_range=max_range,
+                                                                      use_custom_impl=use_custom_impl)
 
             assert isinstance(min_range,
-                              np.ndarray), f'min_range is expected to be numpy array, but is of type {type(min_range)}'
+                              list), f'min_range is expected to be a list, but is of type {type(min_range)}'
             assert isinstance(max_range,
-                              np.ndarray), f'max_range is expected to be numpy array, but is of type {type(max_range)}'
-            assert min_range.ndim == 1, f'min_range is expected to be flatten, but of shape {min_range.shape}'
-            assert max_range.ndim == 1, f'max_range is expected to be flatten, but of shape {min_range.shape}'
+                              list), f'max_range is expected to be a list, but is of type {type(max_range)}'
+            # TODO: fix error msgs
+            assert len(min_range) == 1, f'min_range is expected to be flatten, but of shape {min_range.shape}'
+            assert len(max_range) == 1, f'max_range is expected to be flatten, but of shape {min_range.shape}'
 
             assert len(
                 min_range) == 1, f'For activation, quantization per channel is not supported and min_range should be ' \
@@ -70,6 +145,9 @@ if FOUND_TORCH:
             a = 0 if min_range > 0 else min_range
             b = 0 if max_range < 0 else max_range
 
+            self.min_range = a
+            self.max_range = b
+
             self.scale = float((b - a) / ((2 ** num_bits) - 1))
             self.zero_point = int(-np.round(a / self.scale))  # zp has to be positive, and a <=0, so we multiply by -1
 
@@ -83,12 +161,33 @@ if FOUND_TORCH:
             Returns:
                 quantized tensor.
             """
-            return torch.fake_quantize_per_tensor_affine(inputs,
-                                                         scale=self.scale,
-                                                         zero_point=self.zero_point,
-                                                         quant_min=self.min_quantized_domain,
-                                                         quant_max=self.max_quantized_domain)
+            if self.use_custom_impl and torch.jit.is_tracing():
+                return ActivationUniformF.apply(inputs, self.min_range, self.max_range, self.num_bits)
+            else:
+                with torch.no_grad():
+                    return torch.fake_quantize_per_tensor_affine(inputs,
+                                                                 scale=self.scale,
+                                                                 zero_point=self.zero_point,
+                                                                 quant_min=self.min_quantized_domain,
+                                                                 quant_max=self.max_quantized_domain)
 
+
+    class ActivationUniformF(torch.autograd.Function):
+
+        @staticmethod
+        def forward(ctx, input_tensor, min_range, max_range, num_bits):
+            return quantize_uniform_activations_torch(input_tensor, min_range, max_range, num_bits)
+
+        @staticmethod
+        def symbolic(g, input_tensor, min_range, max_range, num_bits):
+            return g.op("ai.onnx.contrib::ActivationUniformQuantizer", input_tensor,
+                        g.op('Constant', value_t=torch.tensor(min_range, dtype=torch.float32)),
+                        g.op('Constant', value_t=torch.tensor(max_range, dtype=torch.float32)),
+                        g.op('Constant', value_t=torch.tensor(num_bits, dtype=torch.int64))).setType(
+                input_tensor.type())
+
+        def backward(ctx: Any, *grad_outputs: Any) -> Any:
+            raise NotImplementedError()
 
 else:
     class ActivationUniformInferableQuantizer:  # pragma: no cover

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -55,7 +55,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
         return q
 
     # Add onnx op function to use during onnxruntime ActivationUniformQuantizer op inference
-    @onnx_op(op_type="ActivationUniformQuantizer",
+    @onnx_op(op_type="mct_quantizers::ActivationUniformQuantizer",
              inputs=[PyCustomOpDef.dt_float],
              outputs=[PyCustomOpDef.dt_float],
              attrs={"num_bits": PyCustomOpDef.dt_int64,
@@ -222,7 +222,7 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
-            return g.op("ai.onnx.contrib::ActivationUniformQuantizer", input_tensor,
+            return g.op("mct_quantizers::ActivationUniformQuantizer", input_tensor,
                         min_range_f=min_range,
                         max_range_f=max_range,
                         num_bits_i=num_bits

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -173,7 +173,7 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
-            return g.op("mct_quantizers::ActivationUniformQuantizer", input_tensor,
+            return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::ActivationUniformQuantizer", input_tensor,
                         min_range_f=min_range,
                         max_range_f=max_range,
                         num_bits_i=num_bits

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -24,7 +24,6 @@ from mct_quantizers.common.quant_utils import adjust_range_to_include_zero
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.base_uniform_inferable_quantizer import BaseUniformInferableQuantizer
-    from mct_quantizers.pytorch.quantizer_utils import fix_range_to_include_zero, get_working_device
     from mct_quantizers.pytorch.constants import ONNX_CUSTOM_OP_DOMAIN
 
 
@@ -89,8 +88,8 @@ if FOUND_TORCH:
                                                                       min_range=min_range,
                                                                       max_range=max_range)
 
-            assert isinstance(min_range,list), f'min_range is expected to be a list, but is of type {type(min_range)}'
-            assert isinstance(max_range,list), f'max_range is expected to be a list, but is of type {type(max_range)}'
+            assert isinstance(min_range, list), f'min_range is expected to be a list, but is of type {type(min_range)}'
+            assert isinstance(max_range, list), f'max_range is expected to be a list, but is of type {type(max_range)}'
 
             assert len(
                 min_range) == 1, f'For activation, quantization per channel is not supported and min_range should be ' \
@@ -199,9 +198,9 @@ else:
                             'when using ActivationUniformInferableQuantizer. '
                             'Could not find torch package.')
 
-
 if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
+
 
     def quantize_uniform_activations_numpy(tensor_data: np.ndarray,
                                            range_min: float,
@@ -233,6 +232,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
         q = delta * np.round((clipped_tensor - a) / delta) + a
         return q
 
+
     # Add onnx op function to use during onnxruntime ActivationUniformQuantizer op inference
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::ActivationUniformQuantizer",
              inputs=[PyCustomOpDef.dt_float],
@@ -247,4 +247,3 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
                                                   kwargs["min_range"],
                                                   kwargs["max_range"],
                                                   kwargs["num_bits"])
-

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -227,6 +227,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
 
 
     # Add onnx op function to use during onnxruntime ActivationUniformQuantizer op inference
+    # Using this decorator the op ActivationUniformQuantizer is defined using its inputs, outputs and attributes.
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::ActivationUniformQuantizer",
              inputs=[PyCustomOpDef.dt_float],
              outputs=[PyCustomOpDef.dt_float],

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any
 
 import numpy as np
 

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/base_activation_quantizer_autograd_function.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/base_activation_quantizer_autograd_function.py
@@ -12,5 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import Any
 
-ONNX_CUSTOM_OP_DOMAIN = f"mct_quantizers"
+import torch
+
+from mct_quantizers.pytorch.quantizers.base_quantizer_autograd_function import BaseQuantizerAutogradFunction
+
+
+class BaseActivationQuantizerAutogradFunction(BaseQuantizerAutogradFunction):
+    """
+    Custom autograd function for quantizer.
+    It provides a way to define a custom forward and symbolic operation
+    and currently does not implement a backward operation.
+    """
+

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/base_activation_quantizer_autograd_function.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/base_activation_quantizer_autograd_function.py
@@ -12,16 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any
-
-import torch
 
 from mct_quantizers.pytorch.quantizers.base_quantizer_autograd_function import BaseQuantizerAutogradFunction
 
 
 class BaseActivationQuantizerAutogradFunction(BaseQuantizerAutogradFunction):
     """
-    Custom autograd function for quantizer.
+    Custom autograd function for activation quantizers.
     It provides a way to define a custom forward and symbolic operation
     and currently does not implement a backward operation.
     """

--- a/mct_quantizers/pytorch/quantizers/base_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_lut_symmetric_inferable_quantizer.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import numpy as np
 import warnings
+
+import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-
 if FOUND_TORCH:
     from mct_quantizers.pytorch.quantizers.base_pytorch_inferable_quantizer import BasePyTorchInferableQuantizer
+
 
     @mark_quantizer(quantization_target=None,
                     quantization_method=[QuantizationMethod.LUT_SYM_QUANTIZER],

--- a/mct_quantizers/pytorch/quantizers/base_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_lut_symmetric_inferable_quantizer.py
@@ -23,7 +23,6 @@ from mct_quantizers.common.quant_info import QuantizationMethod
 if FOUND_TORCH:
     from mct_quantizers.pytorch.quantizers.base_pytorch_inferable_quantizer import BasePyTorchInferableQuantizer
 
-
     @mark_quantizer(quantization_target=None,
                     quantization_method=[QuantizationMethod.LUT_SYM_QUANTIZER],
                     identifier=QuantizerID.INFERABLE)

--- a/mct_quantizers/pytorch/quantizers/base_pytorch_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_pytorch_inferable_quantizer.py
@@ -22,11 +22,12 @@ if FOUND_TORCH:
 
 
     class BasePyTorchInferableQuantizer(BaseInferableQuantizer):
-        def __init__(self):
+        def __init__(self, use_custom_impl=False):
             """
             This class is a base quantizer for PyTorch quantizers for inference only.
             """
             super(BasePyTorchInferableQuantizer, self).__init__()
+            self.use_custom_impl = use_custom_impl
 
         @abstractmethod
         def __call__(self, inputs: torch.Tensor):

--- a/mct_quantizers/pytorch/quantizers/base_pytorch_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_pytorch_inferable_quantizer.py
@@ -22,12 +22,17 @@ if FOUND_TORCH:
 
 
     class BasePyTorchInferableQuantizer(BaseInferableQuantizer):
-        def __init__(self, use_custom_impl=False):
+        def __init__(self):
             """
             This class is a base quantizer for PyTorch quantizers for inference only.
             """
             super(BasePyTorchInferableQuantizer, self).__init__()
-            self.use_custom_impl = use_custom_impl
+            # By default the custom forward implementation is disabled. If someone wants to enable it
+            # enable_custom_impl should be invoked.
+            self._use_custom_impl = False
+
+        def enable_custom_impl(self):
+            self._use_custom_impl = True
 
         @abstractmethod
         def __call__(self, inputs: torch.Tensor):

--- a/mct_quantizers/pytorch/quantizers/base_quantizer_autograd_function.py
+++ b/mct_quantizers/pytorch/quantizers/base_quantizer_autograd_function.py
@@ -15,7 +15,7 @@
 from typing import Any
 
 import torch
-
+from mct_quantizers import __version__ as mctq_version
 
 class BaseQuantizerAutogradFunction(torch.autograd.Function):
     """
@@ -23,10 +23,6 @@ class BaseQuantizerAutogradFunction(torch.autograd.Function):
     It provides a way to define a custom forward and symbolic operation
     and currently does not implement a backward operation.
     """
-
-    # @staticmethod
-    # def is_signed():
-    #     return True
 
     @staticmethod
     def forward(ctx, input_tensor, **kwargs):
@@ -50,3 +46,7 @@ class BaseQuantizerAutogradFunction(torch.autograd.Function):
             grad_outputs (Any): Gradients w.r.t. the output tensor.
         """
         raise NotImplementedError()
+
+    @staticmethod
+    def _get_metadata_attributes():
+        return {"mctq_version_s": mctq_version}

--- a/mct_quantizers/pytorch/quantizers/base_quantizer_autograd_function.py
+++ b/mct_quantizers/pytorch/quantizers/base_quantizer_autograd_function.py
@@ -1,0 +1,52 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import Any
+
+import torch
+
+
+class BaseQuantizerAutogradFunction(torch.autograd.Function):
+    """
+    Custom autograd function for quantizer.
+    It provides a way to define a custom forward and symbolic operation
+    and currently does not implement a backward operation.
+    """
+
+    # @staticmethod
+    # def is_signed():
+    #     return True
+
+    @staticmethod
+    def forward(ctx, input_tensor, **kwargs):
+        """
+         Forward computation function. This method performs the forward computation using
+         the given quantize_sym_weights_torch function.
+         """
+        raise NotImplemented
+
+    @staticmethod
+    def symbolic(g, input_tensor, **kwargs):
+        raise NotImplemented
+
+    def backward(ctx: Any, *grad_outputs: Any) -> Any:
+        """
+        Backward computation function. Raises a NotImplementedError
+        since backward is not needed for this op.
+
+        Args:
+            ctx (Any): A context object from the forward pass.
+            grad_outputs (Any): Gradients w.r.t. the output tensor.
+        """
+        raise NotImplementedError()

--- a/mct_quantizers/pytorch/quantizers/base_quantizer_autograd_function.py
+++ b/mct_quantizers/pytorch/quantizers/base_quantizer_autograd_function.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any
+from typing import Any, Dict
 
 import torch
 from mct_quantizers import __version__ as mctq_version
@@ -48,5 +48,10 @@ class BaseQuantizerAutogradFunction(torch.autograd.Function):
         raise NotImplementedError()
 
     @staticmethod
-    def _get_metadata_attributes():
+    def _get_metadata_attributes() -> Dict[str,Any]:
+        """
+
+        Returns: Metadata dictionary for all quantizers onnx symbolic ops.
+
+        """
         return {"mctq_version_s": mctq_version}

--- a/mct_quantizers/pytorch/quantizers/base_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_symmetric_inferable_quantizer.py
@@ -23,6 +23,7 @@ from mct_quantizers.common.quant_info import QuantizationMethod
 if FOUND_TORCH:
     from mct_quantizers.pytorch.quantizers.base_pytorch_inferable_quantizer import BasePyTorchInferableQuantizer
 
+
     @mark_quantizer(quantization_target=None,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
                     identifier=QuantizerID.INFERABLE)

--- a/mct_quantizers/pytorch/quantizers/base_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_symmetric_inferable_quantizer.py
@@ -31,8 +31,7 @@ if FOUND_TORCH:
         def __init__(self,
                      num_bits: int,
                      threshold: List[float],
-                     signed: bool,
-                     use_custom_impl=False):
+                     signed: bool):
             """
             Initialize the quantizer with the specified parameters.
 
@@ -42,7 +41,7 @@ if FOUND_TORCH:
                 signed: whether or not to use signed quantization
             """
 
-            super(BaseSymmetricInferableQuantizer, self).__init__(use_custom_impl)
+            super(BaseSymmetricInferableQuantizer, self).__init__()
 
             assert isinstance(threshold, list), f'Threshold is expected to be a list, but is of type {type(threshold)}'
 

--- a/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
@@ -18,9 +18,9 @@ from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, Quant
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-
 if FOUND_TORCH:
     from mct_quantizers.pytorch.quantizers.base_pytorch_inferable_quantizer import BasePyTorchInferableQuantizer
+
 
     @mark_quantizer(quantization_target=None,
                     quantization_method=[QuantizationMethod.UNIFORM],
@@ -30,7 +30,8 @@ if FOUND_TORCH:
         def __init__(self,
                      num_bits: int,
                      min_range: np.ndarray,
-                     max_range: np.ndarray):
+                     max_range: np.ndarray,
+                     use_custom_impl: bool = False):
             """
             Initialize the quantizer with the specified parameters.
 
@@ -40,7 +41,7 @@ if FOUND_TORCH:
                 max_range: max quantization range for quantizing
             """
 
-            super(BaseUniformInferableQuantizer, self).__init__()
+            super(BaseUniformInferableQuantizer, self).__init__(use_custom_impl)
             self.num_bits = num_bits
             self.min_range = min_range
             self.max_range = max_range

--- a/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
@@ -30,8 +30,7 @@ if FOUND_TORCH:
         def __init__(self,
                      num_bits: int,
                      min_range: np.ndarray,
-                     max_range: np.ndarray,
-                     use_custom_impl: bool = False):
+                     max_range: np.ndarray):
             """
             Initialize the quantizer with the specified parameters.
 
@@ -41,7 +40,7 @@ if FOUND_TORCH:
                 max_range: max quantization range for quantizing
             """
 
-            super(BaseUniformInferableQuantizer, self).__init__(use_custom_impl)
+            super(BaseUniformInferableQuantizer, self).__init__()
             self.num_bits = num_bits
             self.min_range = min_range
             self.max_range = max_range

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/base_weight_quantizer_autograd_function.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/base_weight_quantizer_autograd_function.py
@@ -12,16 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any
-
-import torch
 
 from mct_quantizers.pytorch.quantizers.base_quantizer_autograd_function import BaseQuantizerAutogradFunction
 
 
 class BaseWeightQuantizerAutogradFunction(BaseQuantizerAutogradFunction):
     """
-    Custom autograd function for quantizer.
+    Custom autograd function for weights quantizer.
     It provides a way to define a custom forward and symbolic operation
     and currently does not implement a backward operation.
     """

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/base_weight_quantizer_autograd_function.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/base_weight_quantizer_autograd_function.py
@@ -1,0 +1,31 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import Any
+
+import torch
+
+from mct_quantizers.pytorch.quantizers.base_quantizer_autograd_function import BaseQuantizerAutogradFunction
+
+
+class BaseWeightQuantizerAutogradFunction(BaseQuantizerAutogradFunction):
+    """
+    Custom autograd function for quantizer.
+    It provides a way to define a custom forward and symbolic operation
+    and currently does not implement a backward operation.
+    """
+
+    @staticmethod
+    def is_signed():
+        return True

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
@@ -19,10 +19,11 @@ from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, Quant
 from mct_quantizers.common.constants import FOUND_TORCH, LUT_VALUES_BITWIDTH, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-
 if FOUND_TORCH:
-    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_symmetric_inferable_quantizer import \
+    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_symmetric_inferable_quantizer \
+        import \
         WeightsLUTSymmetricInferableQuantizer
+
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.LUT_POT_QUANTIZER],

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
@@ -19,12 +19,12 @@ from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, Quant
 from mct_quantizers.common.constants import FOUND_TORCH, LUT_VALUES_BITWIDTH, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizer_utils import to_torch_tensor, get_working_device, lut_quantizer
     from mct_quantizers.pytorch.quantizers.base_lut_symmetric_inferable_quantizer import \
         BaseLUTSymmetricInferableQuantizer
+
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.LUT_SYM_QUANTIZER],

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -128,7 +128,7 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
-            return g.op("mct_quantizers::WeightsPOTQuantizer", input_tensor,
+            return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsPOTQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
                         num_bits_i=num_bits,
                         per_channel_i=int(per_channel),

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, List
+from typing import Any
 
 import numpy as np
 
@@ -133,7 +133,7 @@ if FOUND_TORCH:
                         num_bits_i=num_bits,
                         per_channel_i=int(per_channel),
                         channel_axis_i=channel_axis
-            ).setType(
+                        ).setType(
                 input_tensor.type())
 
         def backward(ctx: Any, *grad_outputs: Any) -> Any:
@@ -154,10 +154,11 @@ else:
                             'when using WeightsPOTInferableQuantizer. '
                             'Could not find torch package.')
 
-
 if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
-    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_symmetric_inferable_quantizer import quantize_sym_weights_numpy
+    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_symmetric_inferable_quantizer import \
+        quantize_sym_weights_numpy
+
 
     # Add onnx op function to use during onnxruntime WeightsPOTQuantizer op inference
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsPOTQuantizer",
@@ -165,10 +166,10 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
                      PyCustomOpDef.dt_float],
              outputs=[PyCustomOpDef.dt_float],
              attrs={
-                    "num_bits": PyCustomOpDef.dt_int64,
-                    "per_channel": PyCustomOpDef.dt_int64,
-                    "channel_axis": PyCustomOpDef.dt_int64,
-                    }
+                 "num_bits": PyCustomOpDef.dt_int64,
+                 "per_channel": PyCustomOpDef.dt_int64,
+                 "channel_axis": PyCustomOpDef.dt_int64,
+             }
              )
     def weight_pot_ort(input_tensor: np.ndarray, threshold: np.ndarray, **kwargs):
         return quantize_sym_weights_numpy(input_tensor,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -15,16 +15,13 @@
 from typing import Any
 
 import numpy as np
-from onnxruntime_extensions import onnx_op, PyCustomOpDef
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
-from mct_quantizers.common.constants import FOUND_TORCH
+from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTENSIONS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-if FOUND_TORCH:
-    import torch
-    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_symmetric_inferable_quantizer import \
-        WeightsSymmetricInferableQuantizer, quantize_sym_weights_numpy, quantize_sym_weights_torch
+if FOUND_ONNXRUNTIME_EXTENSIONS:
+    from onnxruntime_extensions import onnx_op, PyCustomOpDef
 
     # Add onnx op function to use during onnxruntime WeightsPOTQuantizer op inference
     @onnx_op(op_type="WeightsPOTQuantizer",
@@ -45,6 +42,10 @@ if FOUND_TORCH:
                                    per_channel,
                                    channel_axis)
 
+if FOUND_TORCH:
+    import torch
+    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_symmetric_inferable_quantizer import \
+        WeightsSymmetricInferableQuantizer, quantize_sym_weights_numpy, quantize_sym_weights_torch
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -25,7 +25,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
     from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_symmetric_inferable_quantizer import quantize_sym_weights_numpy
 
     # Add onnx op function to use during onnxruntime WeightsPOTQuantizer op inference
-    @onnx_op(op_type="WeightsPOTQuantizer",
+    @onnx_op(op_type="mct_quantizers::WeightsPOTQuantizer",
              inputs=[PyCustomOpDef.dt_float,
                      PyCustomOpDef.dt_float],
              outputs=[PyCustomOpDef.dt_float],
@@ -148,7 +148,7 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
-            return g.op("ai.onnx.contrib::WeightsPOTQuantizer", input_tensor,
+            return g.op("mct_quantizers::WeightsPOTQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
                         num_bits_i=num_bits,
                         per_channel_i=int(per_channel),

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import List
 
 import numpy as np
 
@@ -39,7 +40,7 @@ if FOUND_TORCH:
 
         def __init__(self,
                      num_bits: int,
-                     threshold: np.ndarray,
+                     threshold: List[float],
                      per_channel: bool,
                      channel_axis: int = None,
                      ):

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -136,7 +136,8 @@ if FOUND_TORCH:
                         num_bits_i=num_bits,
                         per_channel_i=int(per_channel),
                         channel_axis_i=channel_axis,
-                        signed_i=int(WeightsPOTF.is_signed())
+                        signed_i=int(WeightsPOTF.is_signed()),
+                        **WeightsPOTF._get_metadata_attributes()
                         ).setType(
                 input_tensor.type())
 

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -156,6 +156,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
 
 
     # Add onnx op function to use during onnxruntime WeightsPOTQuantizer op inference
+    # Using this decorator the op WeightsPOTQuantizer is defined using its inputs, outputs and attributes.
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsPOTQuantizer",
              inputs=[PyCustomOpDef.dt_float,
                      PyCustomOpDef.dt_float],

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -22,6 +22,7 @@ from mct_quantizers.common.quant_info import QuantizationMethod
 
 if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
+    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_symmetric_inferable_quantizer import quantize_sym_weights_numpy
 
     # Add onnx op function to use during onnxruntime WeightsPOTQuantizer op inference
     @onnx_op(op_type="WeightsPOTQuantizer",
@@ -45,7 +46,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_symmetric_inferable_quantizer import \
-        WeightsSymmetricInferableQuantizer, quantize_sym_weights_numpy, quantize_sym_weights_torch
+        WeightsSymmetricInferableQuantizer, quantize_sym_weights_torch
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],
@@ -60,7 +61,6 @@ if FOUND_TORCH:
                      threshold: np.ndarray,
                      per_channel: bool,
                      channel_axis: int = None,
-                     use_custom_impl: bool = False
                      ):
 
             """
@@ -76,8 +76,7 @@ if FOUND_TORCH:
             super(WeightsPOTInferableQuantizer, self).__init__(num_bits=num_bits,
                                                                threshold=threshold,
                                                                per_channel=per_channel,
-                                                               channel_axis=channel_axis,
-                                                               use_custom_impl=use_custom_impl)
+                                                               channel_axis=channel_axis)
             self.num_bits = num_bits
             self.threshold = threshold
             self.per_channel = per_channel
@@ -98,7 +97,7 @@ if FOUND_TORCH:
                 quantized tensor.
             """
 
-            if self.use_custom_impl and torch.jit.is_tracing():
+            if self._use_custom_impl and torch.jit.is_tracing():
                 return WeightsPOTF.apply(inputs,
                                          self.num_bits,
                                          self.threshold_np,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -12,17 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import Any
 
 import numpy as np
+from onnxruntime_extensions import onnx_op, PyCustomOpDef
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-
 if FOUND_TORCH:
+    import torch
     from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_symmetric_inferable_quantizer import \
-        WeightsSymmetricInferableQuantizer
+        WeightsSymmetricInferableQuantizer, quantize_sym_weights_numpy, quantize_sym_weights_torch
+
+
+    @onnx_op(op_type="WeightsPOTQuantizer",
+             inputs=[PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_int64,
+                     PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_bool,
+                     PyCustomOpDef.dt_int64],
+             outputs=[PyCustomOpDef.dt_float])
+    def weight_pot_ort(x, nbits, t, pc, axis):
+        return quantize_sym_weights_numpy(x, nbits, t, pc, axis)
+
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.POWER_OF_TWO],
@@ -36,8 +50,11 @@ if FOUND_TORCH:
                      num_bits: int,
                      threshold: np.ndarray,
                      per_channel: bool,
-                     channel_axis: int = None
+                     channel_axis: int = None,
+                     use_custom_impl: bool = False
+
                      ):
+
             """
             Initialize the quantizer with the specified parameters.
 
@@ -51,11 +68,54 @@ if FOUND_TORCH:
             super(WeightsPOTInferableQuantizer, self).__init__(num_bits=num_bits,
                                                                threshold=threshold,
                                                                per_channel=per_channel,
-                                                               channel_axis=channel_axis)
+                                                               channel_axis=channel_axis,
+                                                               use_custom_impl=use_custom_impl)
+            self.num_bits = num_bits
+            self.threshold = threshold
+            self.per_channel = per_channel
+            self.channel_axis = channel_axis
 
-            is_threshold_pot = np.all(np.round(np.log2(threshold.flatten()))==np.log2(threshold.flatten()))
+            is_threshold_pot = np.all(
+                np.round(np.log2(self.threshold_np.flatten())) == np.log2(self.threshold_np.flatten()))
             assert is_threshold_pot, f'Expected threshold to be power of 2 but is {threshold}'
 
+        def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
+            """
+            Quantize the given inputs using the quantizer parameters.
+
+            Args:
+                inputs: input tensor to quantize
+
+            Returns:
+                quantized tensor.
+            """
+
+            if self.use_custom_impl and torch.jit.is_tracing():
+                return WeightsPOTF.apply(inputs,
+                                         self.num_bits,
+                                         self.threshold_np,
+                                         self.per_channel,
+                                         self.channel_axis)
+
+            return super(WeightsPOTInferableQuantizer, self).__call__(inputs)
+
+
+    class WeightsPOTF(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, input_tensor, num_bits, threshold, per_channel, channel_axis):
+            return quantize_sym_weights_torch(input_tensor, num_bits, threshold, per_channel, channel_axis)
+
+        @staticmethod
+        def symbolic(g, input_tensor, num_bits, threshold, per_channel, channel_axis):
+            return g.op("ai.onnx.contrib::WeightsPOTQuantizer", input_tensor,
+                        g.op('Constant', value_t=torch.tensor(num_bits, dtype=torch.int64)),
+                        g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
+                        g.op('Constant', value_t=torch.tensor(per_channel, dtype=torch.bool)),
+                        g.op('Constant', value_t=torch.tensor(channel_axis, dtype=torch.int64))).setType(
+                input_tensor.type())
+
+        def backward(ctx: Any, *grad_outputs: Any) -> Any:
+            raise NotImplementedError()
 
 else:
     class WeightsPOTInferableQuantizer:  # pragma: no cover

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any
 
 import numpy as np
 

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -187,7 +187,7 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
-            return g.op("mct_quantizers::WeightsSymmetricQuantizer", input_tensor,
+            return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsSymmetricQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
                         num_bits_i=num_bits,
                         per_channel_i=int(per_channel),

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -17,14 +17,43 @@ from typing import Any
 import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
-from mct_quantizers.common.constants import FOUND_TORCH
+from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTENSIONS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-if FOUND_TORCH:
-    import torch
-    from mct_quantizers.pytorch.quantizers.base_symmetric_inferable_quantizer import BaseSymmetricInferableQuantizer
-    from mct_quantizers.pytorch.quantizer_utils import to_torch_tensor, get_working_device
+if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
+    def quantize_sym_weights_numpy(input_tensor: np.ndarray,
+                                   num_bits: int,
+                                   threshold: float,
+                                   per_channel: bool,
+                                   channel_axis: int):
+        """
+           Quantizes the input tensor symmetrically using numpy.
+
+           Args:
+               input_tensor (np.ndarray): The input tensor to be quantized.
+               num_bits (int): Number of bits to represent the quantized value.
+               threshold (float): The quantization threshold.
+               per_channel (bool): Quantize input tensor per-channel or per-tensor.
+               channel_axis (int): Axis to quantize the tensor in case of per-channel quantization.
+
+           Returns:
+               Symmetrically quantized tensor.
+        """
+        scale = threshold / (2 ** (num_bits - 1))
+        _min, _max = -threshold, threshold - scale
+        if per_channel:
+            ones = np.ones(input_tensor.ndim)
+            ones[channel_axis] = -1
+            new_shape = tuple([int(x) for x in ones])
+            _min = np.reshape(_min, new_shape)
+            _max = np.reshape(_max, new_shape)
+            scale = np.reshape(scale, new_shape)
+
+        # Use torch.where to clip the values in x
+        clipped_x = np.where(input_tensor < _min, _min, input_tensor)
+        quantized = np.round(np.where(input_tensor > _max, _max, clipped_x) / scale) * scale
+        return quantized
 
     # Add onnx op function to use during onnxruntime WeightsSymmetricQuantizer op inference
     @onnx_op(op_type="WeightsSymmetricQuantizer",
@@ -35,15 +64,21 @@ if FOUND_TORCH:
                      PyCustomOpDef.dt_int64],
              outputs=[PyCustomOpDef.dt_float])
     def weight_sym_ort(input_tensor: np.ndarray,
-                                   num_bits: int,
-                                   threshold: float,
-                                   per_channel: bool,
-                                   channel_axis: int):
+                       num_bits: int,
+                       threshold: float,
+                       per_channel: bool,
+                       channel_axis: int):
         return quantize_sym_weights_numpy(input_tensor,
                                           num_bits,
                                           threshold,
                                           per_channel,
                                           channel_axis)
+
+
+if FOUND_TORCH:
+    import torch
+    from mct_quantizers.pytorch.quantizers.base_symmetric_inferable_quantizer import BaseSymmetricInferableQuantizer
+    from mct_quantizers.pytorch.quantizer_utils import to_torch_tensor, get_working_device
 
 
     def quantize_sym_weights_torch(input_tensor: torch.Tensor,
@@ -84,40 +119,6 @@ if FOUND_TORCH:
         clipped_x = torch.where(input_tensor < _min, _min, input_tensor)
         quantized = torch.round(torch.where(input_tensor > _max, _max, clipped_x) / scale) * scale
 
-        return quantized
-
-
-    def quantize_sym_weights_numpy(input_tensor: np.ndarray,
-                                   num_bits: int,
-                                   threshold: float,
-                                   per_channel: bool,
-                                   channel_axis: int):
-        """
-           Quantizes the input tensor symmetrically using numpy.
-
-           Args:
-               input_tensor (np.ndarray): The input tensor to be quantized.
-               num_bits (int): Number of bits to represent the quantized value.
-               threshold (float): The quantization threshold.
-               per_channel (bool): Quantize input tensor per-channel or per-tensor.
-               channel_axis (int): Axis to quantize the tensor in case of per-channel quantization.
-
-           Returns:
-               Symmetrically quantized tensor.
-        """
-        scale = threshold / (2 ** (num_bits - 1))
-        _min, _max = -threshold, threshold - scale
-        if per_channel:
-            ones = np.ones(input_tensor.ndim)
-            ones[channel_axis] = -1
-            new_shape = tuple([int(x) for x in ones])
-            _min = np.reshape(_min, new_shape)
-            _max = np.reshape(_max, new_shape)
-            scale = np.reshape(scale, new_shape)
-
-        # Use torch.where to clip the values in x
-        clipped_x = np.where(input_tensor < _min, _min, input_tensor)
-        quantized = np.round(np.where(input_tensor > _max, _max, clipped_x) / scale) * scale
         return quantized
 
 

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -25,6 +25,8 @@ if FOUND_TORCH:
     from mct_quantizers.pytorch.quantizers.base_symmetric_inferable_quantizer import BaseSymmetricInferableQuantizer
     from mct_quantizers.pytorch.quantizer_utils import to_torch_tensor, get_working_device
     from mct_quantizers.pytorch.constants import ONNX_CUSTOM_OP_DOMAIN
+    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.base_weight_quantizer_autograd_function import \
+        BaseWeightQuantizerAutogradFunction
 
 
     def quantize_sym_weights_torch(input_tensor: torch.Tensor,
@@ -145,7 +147,7 @@ if FOUND_TORCH:
                                                          quant_max=self.max_quantized_domain)
 
 
-    class WeightsSymmetricF(torch.autograd.Function):
+    class WeightsSymmetricF(BaseWeightQuantizerAutogradFunction):
         """
         Custom autograd function for symmetric weights quantizer.
         It provides a way to define a custom forward and symbolic operation
@@ -191,20 +193,11 @@ if FOUND_TORCH:
                         g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
                         num_bits_i=num_bits,
                         per_channel_i=int(per_channel),
-                        channel_axis_i=channel_axis
+                        channel_axis_i=channel_axis,
+                        signed_i=int(WeightsSymmetricF.is_signed())
                         ).setType(
                 input_tensor.type())
 
-        def backward(ctx: Any, *grad_outputs: Any) -> Any:
-            """
-            Backward computation function. Raises a NotImplementedError
-            since backward is not needed for this op.
-
-            Args:
-                ctx (Any): A context object from the forward pass.
-                grad_outputs (Any): Gradients w.r.t. the output tensor.
-            """
-            raise NotImplementedError()
 
 
 else:

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -56,7 +56,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
         return quantized
 
     # Add onnx op function to use during onnxruntime WeightsSymmetricQuantizer op inference
-    @onnx_op(op_type="WeightsSymmetricQuantizer",
+    @onnx_op(op_type="mct_quantizers::WeightsSymmetricQuantizer",
              inputs=[PyCustomOpDef.dt_float,
                      PyCustomOpDef.dt_float],
              outputs=[PyCustomOpDef.dt_float],
@@ -242,7 +242,7 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
-            return g.op("ai.onnx.contrib::WeightsSymmetricQuantizer", input_tensor,
+            return g.op("mct_quantizers::WeightsSymmetricQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
                         num_bits_i=num_bits,
                         per_channel_i=int(per_channel),

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -134,8 +134,7 @@ if FOUND_TORCH:
                      num_bits: int,
                      threshold: np.ndarray,
                      per_channel: bool,
-                     channel_axis: int = None,
-                     use_custom_impl: bool = False
+                     channel_axis: int = None
                      ):
             """
             Initialize the quantizer with the specified parameters.
@@ -149,8 +148,7 @@ if FOUND_TORCH:
 
             super(WeightsSymmetricInferableQuantizer, self).__init__(threshold=threshold,
                                                                      num_bits=num_bits,
-                                                                     signed=True,
-                                                                     use_custom_impl=use_custom_impl)
+                                                                     signed=True)
 
             if per_channel:
                 assert channel_axis is not None, f'Channel axis is missing in per channel quantization'
@@ -179,7 +177,7 @@ if FOUND_TORCH:
                 quantized tensor.
             """
 
-            if self.use_custom_impl and torch.jit.is_tracing():
+            if self._use_custom_impl and torch.jit.is_tracing():
                 return WeightsSymmetricF.apply(inputs,
                                                self.num_bits,
                                                self.threshold_np,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import Any
 
 import numpy as np
 
@@ -19,11 +20,65 @@ from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, Quant
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.base_symmetric_inferable_quantizer import BaseSymmetricInferableQuantizer
     from mct_quantizers.pytorch.quantizer_utils import to_torch_tensor, get_working_device
+    from onnxruntime_extensions import onnx_op, PyCustomOpDef
+
+
+    @onnx_op(op_type="WeightsSymmetricQuantizer",
+             inputs=[PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_int64,
+                     PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_bool,
+                     PyCustomOpDef.dt_int64],
+             outputs=[PyCustomOpDef.dt_float])
+    def weight_sym_ort(x, nbits, t, pc, axis):
+        return quantize_sym_weights_numpy(x, nbits, t, pc, axis)
+
+
+    def quantize_sym_weights_torch(input_tensor, num_bits, threshold, per_channel, channel_axis):
+        if isinstance(threshold, np.ndarray):
+            threshold = torch.tensor(threshold, dtype=torch.float32).to(get_working_device())
+
+        input_tensor = input_tensor
+        scale = threshold / (2 ** (num_bits - 1))
+        _min, _max = -threshold, threshold - scale
+
+        if per_channel:
+            ones = [1] * input_tensor.ndim
+            ones[channel_axis] = -1
+            new_shape = tuple(ones)
+            # Make sure min_values and max_values have the same shape as x along the first axis
+            _min = torch.reshape(_min, new_shape)
+            _max = torch.reshape(_max, new_shape)
+            scale = torch.reshape(scale, new_shape)
+
+        # Use torch.where to clip the values in x
+        clipped_x = torch.where(input_tensor < _min, _min, input_tensor)
+        quantized = torch.round(torch.where(input_tensor > _max, _max, clipped_x) / scale) * scale
+
+        return quantized
+
+
+    def quantize_sym_weights_numpy(input_tensor, num_bits, threshold, per_channel, channel_axis):
+        scale = threshold / (2 ** (num_bits - 1))
+        _min, _max = -threshold, threshold - scale
+        if per_channel:
+            ones = np.ones(input_tensor.ndim)
+            ones[channel_axis] = -1
+            new_shape = tuple([int(x) for x in ones])
+            # Make sure min_values and max_values have the same shape as x along the first axis
+            _min = np.reshape(_min, new_shape)
+            _max = np.reshape(_max, new_shape)
+            scale = np.reshape(scale, new_shape)
+
+        # Use torch.where to clip the values in x
+        clipped_x = np.where(input_tensor < _min, _min, input_tensor)
+        quantized = np.round(np.where(input_tensor > _max, _max, clipped_x) / scale) * scale
+        return quantized
+
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
                     quantization_method=[QuantizationMethod.SYMMETRIC],
@@ -37,7 +92,8 @@ if FOUND_TORCH:
                      num_bits: int,
                      threshold: np.ndarray,
                      per_channel: bool,
-                     channel_axis: int = None
+                     channel_axis: int = None,
+                     use_custom_impl: bool = False
                      ):
             """
             Initialize the quantizer with the specified parameters.
@@ -51,7 +107,8 @@ if FOUND_TORCH:
 
             super(WeightsSymmetricInferableQuantizer, self).__init__(threshold=threshold,
                                                                      num_bits=num_bits,
-                                                                     signed=True)
+                                                                     signed=True,
+                                                                     use_custom_impl=use_custom_impl)
 
             if per_channel:
                 assert channel_axis is not None, f'Channel axis is missing in per channel quantization'
@@ -60,13 +117,15 @@ if FOUND_TORCH:
                                      f'{len(threshold)}'
             else:
                 assert len(
-                    threshold) == 1, f'In per-tensor quantization threshold should be of length 1 but is {len(threshold)}'
+                    threshold) == 1, f'In per-tensor quantization threshold should be of length 1 but is ' \
+                                     f'{len(threshold)}'
 
             self.per_channel = per_channel
             self.channel_axis = channel_axis
 
             self.scales = to_torch_tensor(self.scales).to(get_working_device())
             self.zero_points = torch.zeros(len(threshold), dtype=torch.int32).to(get_working_device())
+            # self.threshold_np = threshold
 
         def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
             """
@@ -78,6 +137,14 @@ if FOUND_TORCH:
             Returns:
                 quantized tensor.
             """
+
+            if self.use_custom_impl and torch.jit.is_tracing():
+                return WeightsSymmetricF.apply(inputs,
+                                               self.num_bits,
+                                               self.threshold_np,
+                                               self.per_channel,
+                                               self.channel_axis)
+
             inputs.requires_grad = False
             if self.per_channel:
                 return torch.fake_quantize_per_channel_affine(inputs,
@@ -91,6 +158,25 @@ if FOUND_TORCH:
                                                          self.zero_points,
                                                          quant_min=self.min_quantized_domain,
                                                          quant_max=self.max_quantized_domain)
+
+
+    class WeightsSymmetricF(torch.autograd.Function):
+
+        @staticmethod
+        def forward(ctx, input_tensor, num_bits, threshold, per_channel, channel_axis):
+            return quantize_sym_weights_torch(input_tensor, num_bits, threshold, per_channel, channel_axis)
+
+        @staticmethod
+        def symbolic(g, input_tensor, num_bits, threshold, per_channel, channel_axis):
+            return g.op("ai.onnx.contrib::WeightsSymmetricQuantizer", input_tensor,
+                        g.op('Constant', value_t=torch.tensor(num_bits, dtype=torch.int64)),
+                        g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
+                        g.op('Constant', value_t=torch.tensor(per_channel, dtype=torch.bool)),
+                        g.op('Constant', value_t=torch.tensor(channel_axis, dtype=torch.int64))).setType(
+                input_tensor.type())
+
+        def backward(ctx: Any, *grad_outputs: Any) -> Any:
+            raise NotImplementedError()
 
 
 else:

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -194,7 +194,8 @@ if FOUND_TORCH:
                         num_bits_i=num_bits,
                         per_channel_i=int(per_channel),
                         channel_axis_i=channel_axis,
-                        signed_i=int(WeightsSymmetricF.is_signed())
+                        signed_i=int(WeightsSymmetricF.is_signed()),
+                        **WeightsSymmetricF._get_metadata_attributes()
                         ).setType(
                 input_tensor.type())
 

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -245,6 +245,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
 
 
     # Add onnx op function to use during onnxruntime WeightsSymmetricQuantizer op inference
+    # Using this decorator the op WeightsSymmetricQuantizer is defined using its inputs, outputs and attributes.
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsSymmetricQuantizer",
              inputs=[PyCustomOpDef.dt_float,
                      PyCustomOpDef.dt_float],

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -20,7 +20,6 @@ from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, Quant
 from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTENSIONS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
-
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.base_symmetric_inferable_quantizer import BaseSymmetricInferableQuantizer
@@ -215,9 +214,10 @@ else:
                             'when using WeightsSymmetricInferableQuantizer. '
                             'Could not find torch package.')
 
-
 if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
+
+
     def quantize_sym_weights_numpy(input_tensor: np.ndarray,
                                    num_bits: int,
                                    threshold: float,
@@ -250,6 +250,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
         clipped_x = np.where(input_tensor < _min, _min, input_tensor)
         quantized = np.round(np.where(input_tensor > _max, _max, clipped_x) / scale) * scale
         return quantized
+
 
     # Add onnx op function to use during onnxruntime WeightsSymmetricQuantizer op inference
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsSymmetricQuantizer",

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import List
 
 import numpy as np
 
@@ -79,7 +80,7 @@ if FOUND_TORCH:
 
         def __init__(self,
                      num_bits: int,
-                     threshold: np.ndarray,
+                     threshold: List[float],
                      per_channel: bool,
                      channel_axis: int = None
                      ):
@@ -209,8 +210,6 @@ else:
 
 if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
-
-
     def quantize_sym_weights_numpy(input_tensor: np.ndarray,
                                    num_bits: int,
                                    threshold: float,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any
 
 import numpy as np
 

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, List
+from typing import List
 
 import numpy as np
 

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -144,8 +144,7 @@ if FOUND_TORCH:
                      min_range: List[float],
                      max_range: List[float],
                      per_channel: bool,
-                     channel_axis: int = None,
-                     use_custom_impl: bool = False
+                     channel_axis: int = None
                      ):
             """
             Initialize the quantizer with the specified parameters.
@@ -159,8 +158,7 @@ if FOUND_TORCH:
             """
             super(WeightsUniformInferableQuantizer, self).__init__(num_bits=num_bits,
                                                                    min_range=min_range,
-                                                                   max_range=max_range,
-                                                                   use_custom_impl=use_custom_impl)
+                                                                   max_range=max_range)
 
             # Align mix/max numpy arrays so they are torch Tensors on the working device
             min_range = to_torch_tensor(np.asarray(min_range)).to(get_working_device())
@@ -194,7 +192,7 @@ if FOUND_TORCH:
             Returns:
                 quantized weights
             """
-            if self.use_custom_impl and torch.jit.is_tracing():
+            if self._use_custom_impl and torch.jit.is_tracing():
                 return WeightsUniformF.apply(inputs,
                                              self.num_bits,
                                              self.adjusted_min_range_np,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -204,7 +204,7 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
-            return g.op("mct_quantizers::WeightsUniformQuantizer", input_tensor,
+            return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsUniformQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(min_range, dtype=torch.float32)),
                         g.op('Constant', value_t=torch.tensor(max_range, dtype=torch.float32)),
                         num_bits_i=num_bits,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -213,7 +213,8 @@ if FOUND_TORCH:
                         num_bits_i=num_bits,
                         per_channel_i=int(per_channel),
                         channel_axis_i=channel_axis,
-                        signed_i=WeightsUniformF.is_signed()
+                        signed_i=WeightsUniformF.is_signed(),
+                        **WeightsUniformF._get_metadata_attributes()
                         ).setType(
                 input_tensor.type())
 

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -22,13 +22,12 @@ from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.common.quant_utils import adjust_range_to_include_zero
 from mct_quantizers.logger import Logger
 
-
-
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizers.base_uniform_inferable_quantizer import BaseUniformInferableQuantizer
     from mct_quantizers.pytorch.quantizer_utils import fix_range_to_include_zero, get_working_device, to_torch_tensor
     from mct_quantizers.pytorch.constants import ONNX_CUSTOM_OP_DOMAIN
+
 
     def quantize_uniform_weights_torch(input_tensor: torch.Tensor,
                                        num_bits: int,
@@ -74,7 +73,6 @@ if FOUND_TORCH:
         clipped_x = torch.where(input_tensor < a, a, input_tensor)
         quantized = torch.round(torch.where(input_tensor > b, b, clipped_x) / delta) * delta
         return quantized
-
 
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
@@ -233,7 +231,6 @@ else:
                          'when using WeightsUniformInferableQuantizer. '
                          'Could not find torch package.')
 
-
 if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
 
@@ -276,6 +273,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
         clipped_x = np.where(input_tensor < a, a, input_tensor)
         quantized = np.round(np.where(input_tensor > b, b, clipped_x) / delta) * delta
         return quantized
+
 
     # Add onnx op function to use during onnxruntime WeightsUniformQuantizer op inference
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsUniformQuantizer",

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -66,7 +66,7 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
         return quantized
 
     # Add onnx op function to use during onnxruntime WeightsUniformQuantizer op inference
-    @onnx_op(op_type="WeightsUniformQuantizer",
+    @onnx_op(op_type="mct_quantizers::WeightsUniformQuantizer",
              inputs=[PyCustomOpDef.dt_float,
                      PyCustomOpDef.dt_float,
                      PyCustomOpDef.dt_float
@@ -270,7 +270,7 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
-            return g.op("ai.onnx.contrib::WeightsUniformQuantizer", input_tensor,
+            return g.op("mct_quantizers::WeightsUniformQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(min_range, dtype=torch.float32)),
                         g.op('Constant', value_t=torch.tensor(max_range, dtype=torch.float32)),
                         num_bits_i=num_bits,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -229,7 +229,6 @@ else:
 if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
 
-
     def quantize_uniform_weights_numpy(input_tensor: np.ndarray,
                                        num_bits: int,
                                        min_range: np.ndarray,
@@ -269,8 +268,8 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
         quantized = np.round(np.where(input_tensor > b, b, clipped_x) / delta) * delta
         return quantized
 
-
     # Add onnx op function to use during onnxruntime WeightsUniformQuantizer op inference
+    # Using this decorator the op WeightsUniformQuantizer is defined using its inputs, outputs and attributes.
     @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsUniformQuantizer",
              inputs=[PyCustomOpDef.dt_float,
                      PyCustomOpDef.dt_float,

--- a/tests/pytorch_tests/onnx_export_tests/__init__.py
+++ b/tests/pytorch_tests/onnx_export_tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
@@ -27,42 +27,71 @@ from mct_quantizers import pytorch_quantizers
 from mct_quantizers.pytorch.quantizer_utils import get_working_device
 
 
+def _export_model(model, onnx_file_path, inputs_for_inference, opset_version=16):
+    print(f'Exporting model to {onnx_file_path}')
+    torch.onnx.export(model,
+                      inputs_for_inference,
+                      onnx_file_path,
+                      opset_version=opset_version,
+                      verbose=False,
+                      input_names=['input'],
+                      output_names=['output'],
+                      dynamic_axes={'input': {0: 'batch_size'},
+                                    'output': {0: 'batch_size'}})
+
+
+def _check_load_and_inference(onnx_file_path, input_shape=(1, 3, 8, 8)):
+    sess = ort.InferenceSession(onnx_file_path, get_ort_session_options())
+    model_input_np = np.random.rand(*input_shape).astype(np.float32)
+    input_feed = {i.name: t for i, t in zip(sess.get_inputs(), [model_input_np])}
+    sess.run([o.name for o in sess.get_outputs()], input_feed)
+
+
+def _get_qparams_from_input_tensors_for_single_quantizer(onnx_file_path, quantizer_type):
+    # Test correct quantization params in onnx model
+    onnx_model = onnx.load(onnx_file_path)
+    # Create a dictionary with the name of the initializers as the key and their tensor values as the value
+    constname_to_constvalue = {node.output[0]: numpy_helper.to_array(node.attribute[0].t) for node in
+                               onnx_model.graph.node if node.op_type == 'Constant'}
+    q_nodes = [n for n in onnx_model.graph.node if n.op_type == quantizer_type]
+    assert len(q_nodes) == 1
+    node = q_nodes[0]
+    node_qparams = [constname_to_constvalue[input_name] for input_name in node.input if
+                    input_name in constname_to_constvalue]
+
+    return node_qparams
+
+
+def _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, quantizer_type):
+    # Test correct quantization params in onnx model
+    onnx_model = onnx.load(onnx_file_path)
+    q_nodes = [n for n in onnx_model.graph.node if n.op_type == quantizer_type]
+    assert len(q_nodes) == 1
+    node = q_nodes[0]
+    # Extract attributes as a key-value dictionary
+    attributes_dict = {}
+    for attribute in node.attribute:
+        # For simplicity, we're assuming all attributes are of basic types
+        # like float, int, string, etc. Some attributes might be lists or tensors,
+        # so you may need to handle those cases separately.
+        if attribute.HasField('f'):
+            attributes_dict[attribute.name] = attribute.f
+        elif attribute.HasField('i'):
+            attributes_dict[attribute.name] = attribute.i
+        elif attribute.HasField('s'):
+            attributes_dict[attribute.name] = attribute.s.decode('utf-8')
+        # ... handle other data types as necessary
+        else:
+            raise Exception(f'Encountered an unfamiliar attribute type in attribute {attribute}')
+
+    return attributes_dict
+
+
+
 class TestONNXExportActivationQuantizers(unittest.TestCase):
 
     def setUp(self):
         self.device = get_working_device()
-
-    def _export_model(self, model, onnx_file_path, input_shape=(1,3,8,8), opset_version=16):
-        model_input_torch = torch.rand(input_shape)
-        torch.onnx.export(model,
-                          model_input_torch,
-                          onnx_file_path,
-                          opset_version=opset_version,
-                          verbose=False,
-                          input_names=['input'],
-                          output_names=['output'],
-                          dynamic_axes={'input': {0: 'batch_size'},
-                                        'output': {0: 'batch_size'}})
-
-    def _check_load_and_inference(self, onnx_file_path, input_shape=(1,3,8,8)):
-        sess = ort.InferenceSession(onnx_file_path, get_ort_session_options())
-        model_input_np = np.random.rand(*input_shape).astype(np.float32)
-        input_feed = {i.name: t for i, t in zip(sess.get_inputs(), [model_input_np])}
-        sess.run([o.name for o in sess.get_outputs()], input_feed)
-
-    def _get_qparams_for_single_quantizer(self, onnx_file_path, quantizer_type):
-        # Test correct quantization params in onnx model
-        onnx_model = onnx.load(onnx_file_path)
-        # Create a dictionary with the name of the initializers as the key and their tensor values as the value
-        constname_to_constvalue = {node.output[0]: numpy_helper.to_array(node.attribute[0].t) for node in
-                                   onnx_model.graph.node if node.op_type == 'Constant'}
-        q_nodes = [n for n in onnx_model.graph.node if n.op_type == quantizer_type]
-        assert len(q_nodes) == 1
-        node = q_nodes[0]
-        node_qparams = [constname_to_constvalue[input_name] for input_name in node.input if
-                        input_name in constname_to_constvalue]
-        return node_qparams
-
 
     def test_onnx_activation_symmetric(self):
         num_bits = 3
@@ -73,19 +102,21 @@ class TestONNXExportActivationQuantizers(unittest.TestCase):
                                                                              signed=signed)
         quantizer.enable_custom_impl()
         layer_with_quantizer = PytorchActivationQuantizationHolder(quantizer)
+        layer_with_quantizer.to(self.device)
 
         _, onnx_file_path = tempfile.mkstemp('.onnx')
-        self._export_model(layer_with_quantizer,
-                           onnx_file_path)
+        _export_model(layer_with_quantizer,
+                      onnx_file_path,
+                      torch.rand(1, 3, 8, 8).to(self.device))
 
-        self._check_load_and_inference(onnx_file_path)
+        _check_load_and_inference(onnx_file_path)
 
-        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'ActivationSymmetricQuantizer')
-        onnx_threshold = node_qparams[0]
-        onnx_signed = node_qparams[1]
-        onnx_nbits = node_qparams[2]
+        node_qparams = _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, 'ActivationSymmetricQuantizer')
+        onnx_threshold = node_qparams['threshold']
+        onnx_signed = node_qparams['signed']
+        onnx_nbits = node_qparams['num_bits']
 
-        assert onnx_threshold == thresholds, f'Expected threshold in quantizer to be {thresholds} but found ' \
+        assert onnx_threshold == thresholds[0], f'Expected threshold in quantizer to be {thresholds} but found ' \
                                              f'{onnx_threshold}'
         assert onnx_signed == signed, f'Expected signed in quantizer to be {signed} but found {onnx_signed}'
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
@@ -103,19 +134,21 @@ class TestONNXExportActivationQuantizers(unittest.TestCase):
         quantizer.enable_custom_impl()
 
         layer_with_quantizer = PytorchActivationQuantizationHolder(quantizer)
+        layer_with_quantizer.to(self.device)
 
         _, onnx_file_path = tempfile.mkstemp('.onnx')
-        self._export_model(layer_with_quantizer,
-                           onnx_file_path)
+        _export_model(layer_with_quantizer,
+                      onnx_file_path,
+                      torch.rand(1, 3, 8, 8).to(self.device))
 
-        self._check_load_and_inference(onnx_file_path)
+        _check_load_and_inference(onnx_file_path)
 
-        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'ActivationPOTQuantizer')
-        onnx_threshold = node_qparams[0]
-        onnx_signed = node_qparams[1]
-        onnx_nbits = node_qparams[2]
+        node_qparams = _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, 'ActivationPOTQuantizer')
+        onnx_threshold = node_qparams['threshold']
+        onnx_signed = node_qparams['signed']
+        onnx_nbits = node_qparams['num_bits']
 
-        assert onnx_threshold == thresholds, f'Expected threshold in quantizer to be {thresholds} but found ' \
+        assert onnx_threshold == thresholds[0], f'Expected threshold in quantizer to be {thresholds} but found ' \
                                              f'{onnx_threshold}'
         assert onnx_signed == signed, f'Expected signed in quantizer to be {signed} but found {onnx_signed}'
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
@@ -132,20 +165,25 @@ class TestONNXExportActivationQuantizers(unittest.TestCase):
         quantizer.enable_custom_impl()
 
         layer_with_quantizer = PytorchActivationQuantizationHolder(quantizer)
+        layer_with_quantizer.to(self.device)
+
         _, onnx_file_path = tempfile.mkstemp('.onnx')
-        self._export_model(layer_with_quantizer,
-                           onnx_file_path)
+        _export_model(layer_with_quantizer,
+                      onnx_file_path,
+                      torch.rand(1, 3, 8, 8).to(self.device))
 
-        self._check_load_and_inference(onnx_file_path)
 
-        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'ActivationUniformQuantizer')
-        onnx_min_range = node_qparams[0]
-        onnx_max_range = node_qparams[1]
-        onnx_nbits = node_qparams[2]
+        _check_load_and_inference(onnx_file_path)
 
-        assert onnx_min_range == [0], f'Expected threshold in min_range to be 0 (after range correction to include zero)' \
+        node_qparams = _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, 'ActivationUniformQuantizer')
+        onnx_min_range = node_qparams['min_range']
+        onnx_max_range = node_qparams['max_range']
+        onnx_nbits = node_qparams['num_bits']
+
+
+        assert onnx_min_range == 0, f'Expected threshold in min_range to be 0 (after range correction to include zero)' \
                                       f' but found {onnx_min_range}'
-        assert onnx_max_range == max_range, f'Expected max_range in quantizer to be {max_range} but found {onnx_max_range}'
+        assert onnx_max_range == max_range[0], f'Expected max_range in quantizer to be {max_range} but found {onnx_max_range}'
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
 
 

--- a/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
@@ -1,0 +1,149 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import tempfile
+import unittest
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+import torch
+from onnx import numpy_helper
+
+from mct_quantizers import PytorchActivationQuantizationHolder
+from mct_quantizers import get_ort_session_options
+from mct_quantizers import pytorch_quantizers
+from mct_quantizers.pytorch.quantizer_utils import get_working_device
+
+
+class TestONNXExportActivationQuantizers(unittest.TestCase):
+
+    def setUp(self):
+        self.device = get_working_device()
+
+    def _export_model(self, model, onnx_file_path, input_shape=(1,3,8,8), opset_version=16):
+        model_input_torch = torch.rand(input_shape)
+        torch.onnx.export(model,
+                          model_input_torch,
+                          onnx_file_path,
+                          opset_version=opset_version,
+                          verbose=False,
+                          input_names=['input'],
+                          output_names=['output'],
+                          dynamic_axes={'input': {0: 'batch_size'},
+                                        'output': {0: 'batch_size'}})
+
+    def _check_load_and_inference(self, onnx_file_path, input_shape=(1,3,8,8)):
+        sess = ort.InferenceSession(onnx_file_path, get_ort_session_options())
+        model_input_np = np.random.rand(*input_shape).astype(np.float32)
+        input_feed = {i.name: t for i, t in zip(sess.get_inputs(), [model_input_np])}
+        sess.run([o.name for o in sess.get_outputs()], input_feed)
+
+    def _get_qparams_for_single_quantizer(self, onnx_file_path, quantizer_type):
+        # Test correct quantization params in onnx model
+        onnx_model = onnx.load(onnx_file_path)
+        # Create a dictionary with the name of the initializers as the key and their tensor values as the value
+        constname_to_constvalue = {node.output[0]: numpy_helper.to_array(node.attribute[0].t) for node in
+                                   onnx_model.graph.node if node.op_type == 'Constant'}
+        q_nodes = [n for n in onnx_model.graph.node if n.op_type == quantizer_type]
+        assert len(q_nodes) == 1
+        node = q_nodes[0]
+        node_qparams = [constname_to_constvalue[input_name] for input_name in node.input if
+                        input_name in constname_to_constvalue]
+        return node_qparams
+
+
+    def test_onnx_activation_symmetric(self):
+        num_bits = 3
+        thresholds = [5.]
+        signed = False
+        quantizer = pytorch_quantizers.ActivationSymmetricInferableQuantizer(num_bits=num_bits,
+                                                                             threshold=thresholds,
+                                                                             signed=signed,
+                                                                             use_custom_impl=True)
+        layer_with_quantizer = PytorchActivationQuantizationHolder(quantizer)
+
+        _, onnx_file_path = tempfile.mkstemp('.onnx')
+        self._export_model(layer_with_quantizer,
+                           onnx_file_path)
+
+        self._check_load_and_inference(onnx_file_path)
+
+        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'ActivationSymmetricQuantizer')
+        onnx_threshold = node_qparams[0]
+        onnx_signed = node_qparams[1]
+        onnx_nbits = node_qparams[2]
+
+        assert onnx_threshold == thresholds, f'Expected threshold in quantizer to be {thresholds} but found ' \
+                                             f'{onnx_threshold}'
+        assert onnx_signed == signed, f'Expected signed in quantizer to be {signed} but found {onnx_signed}'
+        assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
+
+
+
+
+    def test_onnx_activation_pot(self):
+        num_bits = 3
+        thresholds = [4.]
+        signed = True
+        quantizer = pytorch_quantizers.ActivationPOTInferableQuantizer(num_bits=num_bits,
+                                                    threshold=thresholds,
+                                                    signed=signed,
+                                                    use_custom_impl=True)
+        layer_with_quantizer = PytorchActivationQuantizationHolder(quantizer)
+        _, onnx_file_path = tempfile.mkstemp('.onnx')
+        self._export_model(layer_with_quantizer,
+                           onnx_file_path)
+
+        self._check_load_and_inference(onnx_file_path)
+
+        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'ActivationPOTQuantizer')
+        onnx_threshold = node_qparams[0]
+        onnx_signed = node_qparams[1]
+        onnx_nbits = node_qparams[2]
+
+        assert onnx_threshold == thresholds, f'Expected threshold in quantizer to be {thresholds} but found ' \
+                                             f'{onnx_threshold}'
+        assert onnx_signed == signed, f'Expected signed in quantizer to be {signed} but found {onnx_signed}'
+        assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
+
+
+    def test_onnx_activation_uniform(self):
+        num_bits = 3
+        min_range = [4.]
+        max_range = [5.]
+
+        quantizer = pytorch_quantizers.ActivationUniformInferableQuantizer(num_bits=num_bits,
+                                                                           min_range=min_range,
+                                                                           max_range=max_range,
+                                                                           use_custom_impl=True)
+        layer_with_quantizer = PytorchActivationQuantizationHolder(quantizer)
+        _, onnx_file_path = tempfile.mkstemp('.onnx')
+        self._export_model(layer_with_quantizer,
+                           onnx_file_path)
+
+        self._check_load_and_inference(onnx_file_path)
+
+        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'ActivationUniformQuantizer')
+        onnx_min_range = node_qparams[0]
+        onnx_max_range = node_qparams[1]
+        onnx_nbits = node_qparams[2]
+
+        assert onnx_min_range == [0], f'Expected threshold in min_range to be 0 (after range correction to include zero)' \
+                                      f' but found {onnx_min_range}'
+        assert onnx_max_range == max_range, f'Expected max_range in quantizer to be {max_range} but found {onnx_max_range}'
+        assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
+
+
+

--- a/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from mct_quantizers import __version__ as mctq_version
 import tempfile
 import unittest
 
@@ -59,6 +60,7 @@ def _get_qparams_from_input_tensors_for_single_quantizer(onnx_file_path, quantiz
     node_qparams = [constname_to_constvalue[input_name] for input_name in node.input if
                     input_name in constname_to_constvalue]
 
+
     return node_qparams
 
 
@@ -71,16 +73,12 @@ def _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, quantizer_
     # Extract attributes as a key-value dictionary
     attributes_dict = {}
     for attribute in node.attribute:
-        # For simplicity, we're assuming all attributes are of basic types
-        # like float, int, string, etc. Some attributes might be lists or tensors,
-        # so you may need to handle those cases separately.
         if attribute.HasField('f'):
             attributes_dict[attribute.name] = attribute.f
         elif attribute.HasField('i'):
             attributes_dict[attribute.name] = attribute.i
         elif attribute.HasField('s'):
             attributes_dict[attribute.name] = attribute.s.decode('utf-8')
-        # ... handle other data types as necessary
         else:
             raise Exception(f'Encountered an unfamiliar attribute type in attribute {attribute}')
 
@@ -120,7 +118,7 @@ class TestONNXExportActivationQuantizers(unittest.TestCase):
                                              f'{onnx_threshold}'
         assert onnx_signed == signed, f'Expected signed in quantizer to be {signed} but found {onnx_signed}'
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
-
+        assert node_qparams['mctq_version'] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams["mctq_version"]}'
 
 
 
@@ -152,7 +150,7 @@ class TestONNXExportActivationQuantizers(unittest.TestCase):
                                              f'{onnx_threshold}'
         assert onnx_signed == signed, f'Expected signed in quantizer to be {signed} but found {onnx_signed}'
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
-
+        assert node_qparams['mctq_version'] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams["mctq_version"]}'
 
     def test_onnx_activation_uniform(self):
         num_bits = 3
@@ -185,6 +183,7 @@ class TestONNXExportActivationQuantizers(unittest.TestCase):
                                       f' but found {onnx_min_range}'
         assert onnx_max_range == max_range[0], f'Expected max_range in quantizer to be {max_range} but found {onnx_max_range}'
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
+        assert node_qparams['mctq_version'] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams["mctq_version"]}'
 
 
 

--- a/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
@@ -70,8 +70,8 @@ class TestONNXExportActivationQuantizers(unittest.TestCase):
         signed = False
         quantizer = pytorch_quantizers.ActivationSymmetricInferableQuantizer(num_bits=num_bits,
                                                                              threshold=thresholds,
-                                                                             signed=signed,
-                                                                             use_custom_impl=True)
+                                                                             signed=signed)
+        quantizer.enable_custom_impl()
         layer_with_quantizer = PytorchActivationQuantizationHolder(quantizer)
 
         _, onnx_file_path = tempfile.mkstemp('.onnx')
@@ -99,9 +99,11 @@ class TestONNXExportActivationQuantizers(unittest.TestCase):
         signed = True
         quantizer = pytorch_quantizers.ActivationPOTInferableQuantizer(num_bits=num_bits,
                                                     threshold=thresholds,
-                                                    signed=signed,
-                                                    use_custom_impl=True)
+                                                    signed=signed)
+        quantizer.enable_custom_impl()
+
         layer_with_quantizer = PytorchActivationQuantizationHolder(quantizer)
+
         _, onnx_file_path = tempfile.mkstemp('.onnx')
         self._export_model(layer_with_quantizer,
                            onnx_file_path)
@@ -126,8 +128,9 @@ class TestONNXExportActivationQuantizers(unittest.TestCase):
 
         quantizer = pytorch_quantizers.ActivationUniformInferableQuantizer(num_bits=num_bits,
                                                                            min_range=min_range,
-                                                                           max_range=max_range,
-                                                                           use_custom_impl=True)
+                                                                           max_range=max_range)
+        quantizer.enable_custom_impl()
+
         layer_with_quantizer = PytorchActivationQuantizationHolder(quantizer)
         _, onnx_file_path = tempfile.mkstemp('.onnx')
         self._export_model(layer_with_quantizer,

--- a/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
@@ -25,44 +25,13 @@ from mct_quantizers import PytorchQuantizationWrapper
 from mct_quantizers import get_ort_session_options
 from mct_quantizers import pytorch_quantizers
 from mct_quantizers.pytorch.quantizer_utils import get_working_device
+from tests.pytorch_tests.onnx_export_tests.test_activation_quantizers import _export_model, _check_load_and_inference, _get_qparams_from_attributes_for_single_quantizer, _get_qparams_from_input_tensors_for_single_quantizer
 
 
 class TestONNXExportWeightsQuantizers(unittest.TestCase):
 
     def setUp(self):
         self.device = get_working_device()
-
-    def _export_model(self, model, onnx_file_path, input_shape=(1,3,8,8), opset_version=16):
-        model_input_torch = torch.rand(input_shape).to(get_working_device())
-        torch.onnx.export(model,
-                          model_input_torch,
-                          onnx_file_path,
-                          opset_version=opset_version,
-                          verbose=False,
-                          input_names=['input'],
-                          output_names=['output'],
-                          dynamic_axes={'input': {0: 'batch_size'},
-                                        'output': {0: 'batch_size'}})
-
-    def _check_load_and_inference(self, onnx_file_path, input_shape=(1,3,8,8)):
-        sess = ort.InferenceSession(onnx_file_path, get_ort_session_options())
-        model_input_np = np.random.rand(*input_shape).astype(np.float32)
-        input_feed = {i.name: t for i, t in zip(sess.get_inputs(), [model_input_np])}
-        sess.run([o.name for o in sess.get_outputs()], input_feed)
-
-    def _get_qparams_for_single_quantizer(self, onnx_file_path, quantizer_type):
-        # Test correct quantization params in onnx model
-        onnx_model = onnx.load(onnx_file_path)
-        # Create a dictionary with the name of the initializers as the key and their tensor values as the value
-        constname_to_constvalue = {node.output[0]: numpy_helper.to_array(node.attribute[0].t) for node in
-                                   onnx_model.graph.node if node.op_type == 'Constant'}
-        q_nodes = [n for n in onnx_model.graph.node if n.op_type == quantizer_type]
-        assert len(q_nodes) == 1
-        node = q_nodes[0]
-        node_qparams = [constname_to_constvalue[input_name] for input_name in node.input if
-                        input_name in constname_to_constvalue]
-        return node_qparams
-
 
     def test_onnx_weight_symmetric(self):
         thresholds = [3., 6., 2., 3.]
@@ -80,19 +49,20 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
 
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 5),
                                                           {'weight': quantizer}).to(self.device)
-
         _, onnx_file_path = tempfile.mkstemp('.onnx')
-        self._export_model(layer_with_quantizer,
-                           onnx_file_path)
+        _export_model(layer_with_quantizer,
+                      onnx_file_path,
+                      torch.rand(1, 3, 8, 8).to(self.device))
 
-        self._check_load_and_inference(onnx_file_path)
+        _check_load_and_inference(onnx_file_path)
 
-        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsSymmetricQuantizer')
-        onnx_nbits = node_qparams[0]
-        onnx_threshold = node_qparams[1]
-        onnx_per_channel = node_qparams[2]
-        onnx_channel_axis = node_qparams[3]
+        node_qparams = _get_qparams_from_input_tensors_for_single_quantizer(onnx_file_path, 'WeightsSymmetricQuantizer')
+        onnx_threshold = node_qparams[0]
 
+        node_qparams = _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, 'WeightsSymmetricQuantizer')
+        onnx_nbits = node_qparams['num_bits']
+        onnx_per_channel = node_qparams['per_channel']
+        onnx_channel_axis = node_qparams['channel_axis']
 
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
         assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
@@ -118,16 +88,19 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                                           {'weight': quantizer}).to(self.device)
 
         _, onnx_file_path = tempfile.mkstemp('.onnx')
-        self._export_model(layer_with_quantizer,
-                           onnx_file_path)
+        _export_model(layer_with_quantizer,
+                      onnx_file_path,
+                      torch.rand(1, 3, 8, 8).to(self.device))
 
-        self._check_load_and_inference(onnx_file_path)
+        _check_load_and_inference(onnx_file_path)
 
-        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsPOTQuantizer')
-        onnx_nbits = node_qparams[0]
-        onnx_threshold = node_qparams[1]
-        onnx_per_channel = node_qparams[2]
-        onnx_channel_axis = node_qparams[3]
+        node_qparams = _get_qparams_from_input_tensors_for_single_quantizer(onnx_file_path, 'WeightsPOTQuantizer')
+        onnx_threshold = node_qparams[0]
+
+        node_qparams = _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, 'WeightsPOTQuantizer')
+        onnx_nbits = node_qparams['num_bits']
+        onnx_per_channel = node_qparams['per_channel']
+        onnx_channel_axis = node_qparams['channel_axis']
 
 
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
@@ -155,18 +128,20 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                                           {'weight': quantizer}).to(self.device)
 
         _, onnx_file_path = tempfile.mkstemp('.onnx')
-        self._export_model(layer_with_quantizer,
-                           onnx_file_path)
+        _export_model(layer_with_quantizer,
+                      onnx_file_path,
+                      torch.rand(1, 3, 8, 8).to(self.device))
 
-        self._check_load_and_inference(onnx_file_path)
+        _check_load_and_inference(onnx_file_path)
 
-        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsUniformQuantizer')
-        onnx_nbits = node_qparams[0]
-        onnx_min_range = node_qparams[1]
-        onnx_max_range = node_qparams[2]
-        onnx_per_channel = node_qparams[3]
-        onnx_channel_axis = node_qparams[4]
+        node_qparams = _get_qparams_from_input_tensors_for_single_quantizer(onnx_file_path, 'WeightsUniformQuantizer')
+        onnx_min_range = node_qparams[0]
+        onnx_max_range = node_qparams[1]
 
+        node_qparams = _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, 'WeightsUniformQuantizer')
+        onnx_nbits = node_qparams['num_bits']
+        onnx_per_channel = node_qparams['per_channel']
+        onnx_channel_axis = node_qparams['channel_axis']
 
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
         assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
@@ -198,16 +173,20 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                                           {'weight': quantizer}).to(self.device)
 
         _, onnx_file_path = tempfile.mkstemp('.onnx')
-        self._export_model(layer_with_quantizer,
-                           onnx_file_path)
+        _export_model(layer_with_quantizer,
+                      onnx_file_path,
+                      torch.rand(1, 3, 8, 8).to(self.device))
 
-        self._check_load_and_inference(onnx_file_path)
+        _check_load_and_inference(onnx_file_path)
 
-        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsSymmetricQuantizer')
-        onnx_nbits = node_qparams[0]
-        onnx_threshold = node_qparams[1]
-        onnx_per_channel = node_qparams[2]
-        onnx_channel_axis = node_qparams[3]
+        node_qparams = _get_qparams_from_input_tensors_for_single_quantizer(onnx_file_path, 'WeightsSymmetricQuantizer')
+        onnx_threshold = node_qparams[0]
+
+        node_qparams = _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, 'WeightsSymmetricQuantizer')
+        onnx_nbits = node_qparams['num_bits']
+        onnx_per_channel = node_qparams['per_channel']
+        onnx_channel_axis = node_qparams['channel_axis']
+
 
 
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
@@ -234,16 +213,21 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                                           {'weight': quantizer}).to(self.device)
 
         _, onnx_file_path = tempfile.mkstemp('.onnx')
-        self._export_model(layer_with_quantizer,
-                           onnx_file_path)
+        _export_model(layer_with_quantizer,
+                      onnx_file_path,
+                      torch.rand(1, 3, 8, 8).to(self.device))
 
-        self._check_load_and_inference(onnx_file_path)
+        _check_load_and_inference(onnx_file_path)
 
-        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsPOTQuantizer')
-        onnx_nbits = node_qparams[0]
-        onnx_threshold = node_qparams[1]
-        onnx_per_channel = node_qparams[2]
-        onnx_channel_axis = node_qparams[3]
+        node_qparams = _get_qparams_from_input_tensors_for_single_quantizer(onnx_file_path, 'WeightsPOTQuantizer')
+        onnx_threshold = node_qparams[0]
+
+        node_qparams = _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, 'WeightsPOTQuantizer')
+        onnx_nbits = node_qparams['num_bits']
+        onnx_per_channel = node_qparams['per_channel']
+        onnx_channel_axis = node_qparams['channel_axis']
+
+
 
 
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
@@ -272,17 +256,20 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                                           {'weight': quantizer}).to(self.device)
 
         _, onnx_file_path = tempfile.mkstemp('.onnx')
-        self._export_model(layer_with_quantizer,
-                           onnx_file_path)
+        _export_model(layer_with_quantizer,
+                      onnx_file_path,
+                      torch.rand(1, 3, 8, 8).to(self.device))
 
-        self._check_load_and_inference(onnx_file_path)
+        _check_load_and_inference(onnx_file_path)
 
-        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsUniformQuantizer')
-        onnx_nbits = node_qparams[0]
-        onnx_min_range = node_qparams[1]
-        onnx_max_range = node_qparams[2]
-        onnx_per_channel = node_qparams[3]
-        onnx_channel_axis = node_qparams[4]
+        node_qparams = _get_qparams_from_input_tensors_for_single_quantizer(onnx_file_path, 'WeightsUniformQuantizer')
+        onnx_min_range = node_qparams[0]
+        onnx_max_range = node_qparams[1]
+
+        node_qparams = _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, 'WeightsUniformQuantizer')
+        onnx_nbits = node_qparams['num_bits']
+        onnx_per_channel = node_qparams['per_channel']
+        onnx_channel_axis = node_qparams['channel_axis']
 
 
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'

--- a/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
@@ -69,6 +69,8 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         assert np.all(thresholds==onnx_threshold), f'Expected threshold in quantizer to be {thresholds} but found {onnx_threshold}'
         assert onnx_channel_axis == channel_axis, f'Expected threshold in quantizer to be {channel_axis} but found ' \
                                              f'{onnx_channel_axis}'
+        onnx_signed = node_qparams['signed']
+        assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
 
 
     def test_onnx_weight_pot(self):
@@ -108,6 +110,9 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         assert np.all(thresholds==onnx_threshold), f'Expected threshold in quantizer to be {thresholds} but found {onnx_threshold}'
         assert onnx_channel_axis == channel_axis, f'Expected threshold in quantizer to be {channel_axis} but found ' \
                                              f'{onnx_channel_axis}'
+
+        onnx_signed = node_qparams['signed']
+        assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
 
 
     def test_onnx_weight_uniform(self):
@@ -149,11 +154,8 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         assert np.all(max_range==onnx_max_range), f'Expected max_range in quantizer to be {max_range} but found {onnx_max_range}'
         assert onnx_channel_axis == channel_axis, f'Expected channel_axis in quantizer to be {channel_axis} but found {onnx_channel_axis}'
 
-
-
-
-
-
+        onnx_signed = node_qparams['signed']
+        assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
 
     def test_onnx_weight_symmetric_per_tensor(self):
         thresholds = [3.]
@@ -194,6 +196,8 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         assert np.all(thresholds==onnx_threshold), f'Expected threshold in quantizer to be {thresholds} but found {onnx_threshold}'
         assert onnx_channel_axis == channel_axis, f'Expected threshold in quantizer to be {channel_axis} but found ' \
                                              f'{onnx_channel_axis}'
+        onnx_signed = node_qparams['signed']
+        assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
 
 
     def test_onnx_weight_pot_per_tensor(self):
@@ -227,14 +231,13 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         onnx_per_channel = node_qparams['per_channel']
         onnx_channel_axis = node_qparams['channel_axis']
 
-
-
-
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
         assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
         assert np.all(thresholds==onnx_threshold), f'Expected threshold in quantizer to be {thresholds} but found {onnx_threshold}'
         assert onnx_channel_axis == channel_axis, f'Expected threshold in quantizer to be {channel_axis} but found ' \
                                              f'{onnx_channel_axis}'
+        onnx_signed = node_qparams['signed']
+        assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
 
 
     def test_onnx_weight_uniform_per_tensor(self):
@@ -277,6 +280,8 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         assert np.all(np.zeros(shape=(1,))==onnx_min_range), f'Expected min_range in quantizer to be zeros after range adjustment but found {onnx_min_range}'
         assert np.all(max_range==onnx_max_range), f'Expected max_range in quantizer to be {max_range} but found {onnx_max_range}'
         assert onnx_channel_axis == channel_axis, f'Expected channel_axis in quantizer to be {channel_axis} but found {onnx_channel_axis}'
+        onnx_signed = node_qparams['signed']
+        assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
 
 
 

--- a/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from mct_quantizers import __version__ as mctq_version
+
 import tempfile
 import unittest
 
@@ -71,6 +73,7 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                              f'{onnx_channel_axis}'
         onnx_signed = node_qparams['signed']
         assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
+        assert node_qparams['mctq_version'] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams["mctq_version"]}'
 
 
     def test_onnx_weight_pot(self):
@@ -113,6 +116,7 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
 
         onnx_signed = node_qparams['signed']
         assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
+        assert node_qparams['mctq_version'] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams["mctq_version"]}'
 
 
     def test_onnx_weight_uniform(self):
@@ -156,6 +160,7 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
 
         onnx_signed = node_qparams['signed']
         assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
+        assert node_qparams['mctq_version'] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams["mctq_version"]}'
 
     def test_onnx_weight_symmetric_per_tensor(self):
         thresholds = [3.]
@@ -188,6 +193,7 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         onnx_nbits = node_qparams['num_bits']
         onnx_per_channel = node_qparams['per_channel']
         onnx_channel_axis = node_qparams['channel_axis']
+        assert node_qparams['mctq_version'] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams["mctq_version"]}'
 
 
 
@@ -238,6 +244,7 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                              f'{onnx_channel_axis}'
         onnx_signed = node_qparams['signed']
         assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
+        assert node_qparams['mctq_version'] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams["mctq_version"]}'
 
 
     def test_onnx_weight_uniform_per_tensor(self):
@@ -282,6 +289,7 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         assert onnx_channel_axis == channel_axis, f'Expected channel_axis in quantizer to be {channel_axis} but found {onnx_channel_axis}'
         onnx_signed = node_qparams['signed']
         assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
+        assert node_qparams['mctq_version'] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams["mctq_version"]}'
 
 
 

--- a/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
@@ -1,0 +1,292 @@
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import tempfile
+import unittest
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+import torch
+from onnx import numpy_helper
+
+from mct_quantizers import PytorchQuantizationWrapper
+from mct_quantizers import get_ort_session_options
+from mct_quantizers import pytorch_quantizers
+from mct_quantizers.pytorch.quantizer_utils import get_working_device
+
+
+class TestONNXExportWeightsQuantizers(unittest.TestCase):
+
+    def setUp(self):
+        self.device = get_working_device()
+
+    def _export_model(self, model, onnx_file_path, input_shape=(1,3,8,8), opset_version=16):
+        model_input_torch = torch.rand(input_shape).to(get_working_device())
+        torch.onnx.export(model,
+                          model_input_torch,
+                          onnx_file_path,
+                          opset_version=opset_version,
+                          verbose=False,
+                          input_names=['input'],
+                          output_names=['output'],
+                          dynamic_axes={'input': {0: 'batch_size'},
+                                        'output': {0: 'batch_size'}})
+
+    def _check_load_and_inference(self, onnx_file_path, input_shape=(1,3,8,8)):
+        sess = ort.InferenceSession(onnx_file_path, get_ort_session_options())
+        model_input_np = np.random.rand(*input_shape).astype(np.float32)
+        input_feed = {i.name: t for i, t in zip(sess.get_inputs(), [model_input_np])}
+        sess.run([o.name for o in sess.get_outputs()], input_feed)
+
+    def _get_qparams_for_single_quantizer(self, onnx_file_path, quantizer_type):
+        # Test correct quantization params in onnx model
+        onnx_model = onnx.load(onnx_file_path)
+        # Create a dictionary with the name of the initializers as the key and their tensor values as the value
+        constname_to_constvalue = {node.output[0]: numpy_helper.to_array(node.attribute[0].t) for node in
+                                   onnx_model.graph.node if node.op_type == 'Constant'}
+        q_nodes = [n for n in onnx_model.graph.node if n.op_type == quantizer_type]
+        assert len(q_nodes) == 1
+        node = q_nodes[0]
+        node_qparams = [constname_to_constvalue[input_name] for input_name in node.input if
+                        input_name in constname_to_constvalue]
+        return node_qparams
+
+
+    def test_onnx_weight_symmetric(self):
+        thresholds = [3., 6., 2., 3.]
+        num_bits = 2
+        per_channel = True
+        channel_axis = 0
+
+        quantizer = pytorch_quantizers.WeightsSymmetricInferableQuantizer(num_bits=num_bits,
+                                                                          per_channel=per_channel,
+                                                                          threshold=thresholds,
+                                                                          channel_axis=channel_axis,
+                                                                          use_custom_impl=True
+                                                                          )
+
+        layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 5),
+                                                          {'weight': quantizer}).to(self.device)
+
+        _, onnx_file_path = tempfile.mkstemp('.onnx')
+        self._export_model(layer_with_quantizer,
+                           onnx_file_path)
+
+        self._check_load_and_inference(onnx_file_path)
+
+        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsSymmetricQuantizer')
+        onnx_nbits = node_qparams[0]
+        onnx_threshold = node_qparams[1]
+        onnx_per_channel = node_qparams[2]
+        onnx_channel_axis = node_qparams[3]
+
+
+        assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
+        assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
+        assert np.all(thresholds==onnx_threshold), f'Expected threshold in quantizer to be {thresholds} but found {onnx_threshold}'
+        assert onnx_channel_axis == channel_axis, f'Expected threshold in quantizer to be {channel_axis} but found ' \
+                                             f'{onnx_channel_axis}'
+
+
+    def test_onnx_weight_pot(self):
+        thresholds = [0.5, 0.25, 2., 1.]
+        num_bits = 2
+        per_channel = True
+        channel_axis = 0
+
+        quantizer = pytorch_quantizers.WeightsPOTInferableQuantizer(num_bits=num_bits,
+                                                                    per_channel=per_channel,
+                                                                    threshold=thresholds,
+                                                                    channel_axis=channel_axis,
+                                                                    use_custom_impl=True
+                                                                    )
+
+        layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 3),
+                                                          {'weight': quantizer}).to(self.device)
+
+        _, onnx_file_path = tempfile.mkstemp('.onnx')
+        self._export_model(layer_with_quantizer,
+                           onnx_file_path)
+
+        self._check_load_and_inference(onnx_file_path)
+
+        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsPOTQuantizer')
+        onnx_nbits = node_qparams[0]
+        onnx_threshold = node_qparams[1]
+        onnx_per_channel = node_qparams[2]
+        onnx_channel_axis = node_qparams[3]
+
+
+        assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
+        assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
+        assert np.all(thresholds==onnx_threshold), f'Expected threshold in quantizer to be {thresholds} but found {onnx_threshold}'
+        assert onnx_channel_axis == channel_axis, f'Expected threshold in quantizer to be {channel_axis} but found ' \
+                                             f'{onnx_channel_axis}'
+
+
+    def test_onnx_weight_uniform(self):
+        min_range = [0.1, 0.1, 1., 0.]
+        max_range = [0.5, 0.25, 2., 1.]
+        num_bits = 2
+        per_channel = True
+        channel_axis = 0
+
+        quantizer = pytorch_quantizers.WeightsUniformInferableQuantizer(num_bits=num_bits,
+                                                                        min_range=min_range,
+                                                                        max_range=max_range,
+                                                                        per_channel=per_channel,
+                                                                        channel_axis=channel_axis,
+                                                                        use_custom_impl=True)
+
+        layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 3),
+                                                          {'weight': quantizer}).to(self.device)
+
+        _, onnx_file_path = tempfile.mkstemp('.onnx')
+        self._export_model(layer_with_quantizer,
+                           onnx_file_path)
+
+        self._check_load_and_inference(onnx_file_path)
+
+        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsUniformQuantizer')
+        onnx_nbits = node_qparams[0]
+        onnx_min_range = node_qparams[1]
+        onnx_max_range = node_qparams[2]
+        onnx_per_channel = node_qparams[3]
+        onnx_channel_axis = node_qparams[4]
+
+
+        assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
+        assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
+        assert np.all(np.zeros(shape=(4,))==onnx_min_range), f'Expected min_range in quantizer to be zeros after range adjustment but found {onnx_min_range}'
+        assert np.all(max_range==onnx_max_range), f'Expected max_range in quantizer to be {max_range} but found {onnx_max_range}'
+        assert onnx_channel_axis == channel_axis, f'Expected channel_axis in quantizer to be {channel_axis} but found {onnx_channel_axis}'
+
+
+
+
+
+
+
+    def test_onnx_weight_symmetric_per_tensor(self):
+        thresholds = [3.]
+        num_bits = 2
+        per_channel = False
+        channel_axis = 0
+
+        quantizer = pytorch_quantizers.WeightsSymmetricInferableQuantizer(num_bits=num_bits,
+                                                                          per_channel=per_channel,
+                                                                          threshold=thresholds,
+                                                                          channel_axis=channel_axis,
+                                                                          use_custom_impl=True
+                                                                          )
+
+        layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 5),
+                                                          {'weight': quantizer}).to(self.device)
+
+        _, onnx_file_path = tempfile.mkstemp('.onnx')
+        self._export_model(layer_with_quantizer,
+                           onnx_file_path)
+
+        self._check_load_and_inference(onnx_file_path)
+
+        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsSymmetricQuantizer')
+        onnx_nbits = node_qparams[0]
+        onnx_threshold = node_qparams[1]
+        onnx_per_channel = node_qparams[2]
+        onnx_channel_axis = node_qparams[3]
+
+
+        assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
+        assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
+        assert np.all(thresholds==onnx_threshold), f'Expected threshold in quantizer to be {thresholds} but found {onnx_threshold}'
+        assert onnx_channel_axis == channel_axis, f'Expected threshold in quantizer to be {channel_axis} but found ' \
+                                             f'{onnx_channel_axis}'
+
+
+    def test_onnx_weight_pot_per_tensor(self):
+        thresholds = [0.5]
+        num_bits = 2
+        per_channel = False
+        channel_axis = 0
+
+        quantizer = pytorch_quantizers.WeightsPOTInferableQuantizer(num_bits=num_bits,
+                                                                    per_channel=per_channel,
+                                                                    threshold=thresholds,
+                                                                    channel_axis=channel_axis,
+                                                                    use_custom_impl=True
+                                                                    )
+
+        layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 3),
+                                                          {'weight': quantizer}).to(self.device)
+
+        _, onnx_file_path = tempfile.mkstemp('.onnx')
+        self._export_model(layer_with_quantizer,
+                           onnx_file_path)
+
+        self._check_load_and_inference(onnx_file_path)
+
+        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsPOTQuantizer')
+        onnx_nbits = node_qparams[0]
+        onnx_threshold = node_qparams[1]
+        onnx_per_channel = node_qparams[2]
+        onnx_channel_axis = node_qparams[3]
+
+
+        assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
+        assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
+        assert np.all(thresholds==onnx_threshold), f'Expected threshold in quantizer to be {thresholds} but found {onnx_threshold}'
+        assert onnx_channel_axis == channel_axis, f'Expected threshold in quantizer to be {channel_axis} but found ' \
+                                             f'{onnx_channel_axis}'
+
+
+    def test_onnx_weight_uniform_per_tensor(self):
+        min_range = [0.1]
+        max_range = [0.5]
+        num_bits = 2
+        per_channel = False
+        channel_axis = 0
+
+        quantizer = pytorch_quantizers.WeightsUniformInferableQuantizer(num_bits=num_bits,
+                                                                        min_range=min_range,
+                                                                        max_range=max_range,
+                                                                        per_channel=per_channel,
+                                                                        channel_axis=channel_axis,
+                                                                        use_custom_impl=True)
+
+        layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 3),
+                                                          {'weight': quantizer}).to(self.device)
+
+        _, onnx_file_path = tempfile.mkstemp('.onnx')
+        self._export_model(layer_with_quantizer,
+                           onnx_file_path)
+
+        self._check_load_and_inference(onnx_file_path)
+
+        node_qparams = self._get_qparams_for_single_quantizer(onnx_file_path, 'WeightsUniformQuantizer')
+        onnx_nbits = node_qparams[0]
+        onnx_min_range = node_qparams[1]
+        onnx_max_range = node_qparams[2]
+        onnx_per_channel = node_qparams[3]
+        onnx_channel_axis = node_qparams[4]
+
+
+        assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
+        assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
+        assert np.all(np.zeros(shape=(1,))==onnx_min_range), f'Expected min_range in quantizer to be zeros after range adjustment but found {onnx_min_range}'
+        assert np.all(max_range==onnx_max_range), f'Expected max_range in quantizer to be {max_range} but found {onnx_max_range}'
+        assert onnx_channel_axis == channel_axis, f'Expected channel_axis in quantizer to be {channel_axis} but found {onnx_channel_axis}'
+
+
+

--- a/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
@@ -74,8 +74,9 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                                                           per_channel=per_channel,
                                                                           threshold=thresholds,
                                                                           channel_axis=channel_axis,
-                                                                          use_custom_impl=True
                                                                           )
+        quantizer.enable_custom_impl()
+
 
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 5),
                                                           {'weight': quantizer}).to(self.device)
@@ -110,8 +111,8 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                                                     per_channel=per_channel,
                                                                     threshold=thresholds,
                                                                     channel_axis=channel_axis,
-                                                                    use_custom_impl=True
                                                                     )
+        quantizer.enable_custom_impl()
 
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 3),
                                                           {'weight': quantizer}).to(self.device)
@@ -147,8 +148,8 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                                                         min_range=min_range,
                                                                         max_range=max_range,
                                                                         per_channel=per_channel,
-                                                                        channel_axis=channel_axis,
-                                                                        use_custom_impl=True)
+                                                                        channel_axis=channel_axis)
+        quantizer.enable_custom_impl()
 
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 3),
                                                           {'weight': quantizer}).to(self.device)
@@ -188,9 +189,10 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         quantizer = pytorch_quantizers.WeightsSymmetricInferableQuantizer(num_bits=num_bits,
                                                                           per_channel=per_channel,
                                                                           threshold=thresholds,
-                                                                          channel_axis=channel_axis,
-                                                                          use_custom_impl=True
+                                                                          channel_axis=channel_axis
                                                                           )
+        quantizer.enable_custom_impl()
+
 
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 5),
                                                           {'weight': quantizer}).to(self.device)
@@ -224,9 +226,9 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         quantizer = pytorch_quantizers.WeightsPOTInferableQuantizer(num_bits=num_bits,
                                                                     per_channel=per_channel,
                                                                     threshold=thresholds,
-                                                                    channel_axis=channel_axis,
-                                                                    use_custom_impl=True
+                                                                    channel_axis=channel_axis
                                                                     )
+        quantizer.enable_custom_impl()
 
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 3),
                                                           {'weight': quantizer}).to(self.device)
@@ -262,8 +264,9 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                                                         min_range=min_range,
                                                                         max_range=max_range,
                                                                         per_channel=per_channel,
-                                                                        channel_axis=channel_axis,
-                                                                        use_custom_impl=True)
+                                                                        channel_axis=channel_axis)
+        quantizer.enable_custom_impl()
+
 
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 3),
                                                           {'weight': quantizer}).to(self.device)

--- a/tests/pytorch_tests/quantizers_tests/test_activations_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_activations_inferable_quantizer.py
@@ -29,7 +29,7 @@ from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activatio
 class TestPytorchActivationInferableQuantizers(unittest.TestCase):
 
     def test_symmetric_activation_quantizer(self):
-        thresholds = np.asarray([4])
+        thresholds = [4]
         num_bits = 2
         quantizer = ActivationSymmetricInferableQuantizer(num_bits=num_bits,
                                                           threshold=thresholds,
@@ -62,7 +62,7 @@ class TestPytorchActivationInferableQuantizers(unittest.TestCase):
         self.assertTrue(torch.all(manually_quantized_tensor == quantized_tensor))
 
     def test_unsigned_symmetric_activation_quantizer(self):
-        thresholds = np.asarray([4])
+        thresholds = [4]
         num_bits = 2
         quantizer = ActivationSymmetricInferableQuantizer(num_bits=num_bits,
                                                           threshold=thresholds,
@@ -97,7 +97,7 @@ class TestPytorchActivationInferableQuantizers(unittest.TestCase):
         with self.assertRaises(Exception) as e:
             ActivationPOTInferableQuantizer(num_bits=8,
                                             # Not POT threshold
-                                            threshold=np.asarray([3]),
+                                            threshold=[3],
                                             signed=True)
         self.assertEqual('Expected threshold to be power of 2 but is [3]', str(e.exception))
 
@@ -107,10 +107,10 @@ class TestPytorchActivationInferableQuantizers(unittest.TestCase):
                                             threshold=4,
                                             signed=True)
 
-        self.assertEqual('Threshold is expected to be numpy array, but is of type <class \'int\'>', str(e.exception))
+        self.assertEqual('Threshold is expected to be a list, but is of type <class \'int\'>', str(e.exception))
 
     def test_power_of_two_activation_quantizer(self):
-        thresholds = np.asarray([1])
+        thresholds = [1]
         num_bits = 2
         quantizer = ActivationPOTInferableQuantizer(num_bits=num_bits,
                                                     signed=True,
@@ -140,7 +140,7 @@ class TestPytorchActivationInferableQuantizers(unittest.TestCase):
         self.assertTrue(torch.all(manually_quantized_tensor == fake_quantized_tensor))
 
     def test_unsigned_power_of_two_activation_quantizer(self):
-        thresholds = np.asarray([1])
+        thresholds = [1]
         num_bits = 2
         quantizer = ActivationPOTInferableQuantizer(num_bits=num_bits,
                                                     signed=False,
@@ -166,8 +166,8 @@ class TestPytorchActivationInferableQuantizers(unittest.TestCase):
         self.assertTrue(torch.all(manually_quantized_tensor == fake_quantized_tensor))
 
     def test_uniform_activation_quantizer(self):
-        min_range = np.asarray([-10])
-        max_range = np.asarray([5])
+        min_range = [-10]
+        max_range = [5]
         num_bits = 2
         quantizer = ActivationUniformInferableQuantizer(num_bits=num_bits,
                                                         min_range=min_range,
@@ -202,8 +202,8 @@ class TestPytorchActivationInferableQuantizers(unittest.TestCase):
         self.assertTrue(torch.all(manually_quantized_tensor == quantized_tensor))
 
     def test_illegal_range_uniform_activation_quantizer(self):
-        min_range = np.asarray([3])
-        max_range = np.asarray([10])
+        min_range = [3]
+        max_range = [10]
         num_bits = 2
         quantizer = ActivationUniformInferableQuantizer(num_bits=num_bits,
                                                         min_range=min_range,

--- a/tests/pytorch_tests/quantizers_tests/test_illegal_weights_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_illegal_weights_inferable_quantizer.py
@@ -32,7 +32,7 @@ class TestPytorchWeightsIllegalInferableQuantizers(unittest.TestCase):
         with self.assertRaises(Exception) as e:
             WeightsSymmetricInferableQuantizer(num_bits=8,
                                                per_channel=True,
-                                               threshold=np.asarray([1]))
+                                               threshold=[1])
         self.assertEqual('Channel axis is missing in per channel quantization', str(e.exception))
 
     def test_illegal_threshold_not_pot(self):
@@ -40,7 +40,7 @@ class TestPytorchWeightsIllegalInferableQuantizers(unittest.TestCase):
             WeightsPOTInferableQuantizer(num_bits=8,
                                          per_channel=False,
                                          # Not POT threshold
-                                         threshold=np.asarray([3]))
+                                         threshold=[3])
         self.assertEqual('Expected threshold to be power of 2 but is [3]', str(e.exception))
 
     def test_illegal_threshold_length_per_tensor_pot_quantizer(self):
@@ -48,7 +48,7 @@ class TestPytorchWeightsIllegalInferableQuantizers(unittest.TestCase):
             WeightsPOTInferableQuantizer(num_bits=8,
                                          per_channel=False,
                                          # More than one threshold in per-tensor quantization
-                                         threshold=np.asarray([2, 3]))
+                                         threshold=[2, 3])
         self.assertEqual('In per-tensor quantization threshold should be of length 1 but is 2', str(e.exception))
 
     def test_zero_not_in_range_uniform_quantizer(self):

--- a/tests/pytorch_tests/quantizers_tests/test_weights_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_weights_inferable_quantizer.py
@@ -30,7 +30,7 @@ class TestPytorchWeightsInferableQuantizers(unittest.TestCase):
 
     def test_symmetric_weights_quantizer_per_tensor(self):
         num_bits = 3
-        thresholds = np.asarray([4])
+        thresholds = [4]
         quantizer = WeightsSymmetricInferableQuantizer(num_bits=num_bits,
                                                        per_channel=False,
                                                        threshold=thresholds)
@@ -62,7 +62,7 @@ class TestPytorchWeightsInferableQuantizers(unittest.TestCase):
         self.assertTrue(torch.all(manually_quantized_tensor == quantized_tensor))
 
     def test_symmetric_weights_quantizer_per_channel(self):
-        thresholds = np.asarray([3, 6, 2])
+        thresholds = [3, 6, 2]
         num_bits = 2
         quantizer = WeightsSymmetricInferableQuantizer(num_bits=num_bits,
                                                        per_channel=True,
@@ -100,7 +100,7 @@ class TestPytorchWeightsInferableQuantizers(unittest.TestCase):
         self.assertTrue(torch.all(manually_quantized_tensor == quantized_tensor))
 
     def test_pot_weights_quantizer_per_channel(self):
-        thresholds = np.asarray([2, 4, 1])
+        thresholds = [2, 4, 1]
         num_bits = 3
         quantizer = WeightsPOTInferableQuantizer(num_bits=num_bits,
                                                  per_channel=True,
@@ -139,7 +139,7 @@ class TestPytorchWeightsInferableQuantizers(unittest.TestCase):
         self.assertTrue(torch.all(manually_quantized_tensor == fake_quantized_tensor))
 
     def test_pot_weights_quantizer_per_tensor(self):
-        thresholds = np.asarray([1])
+        thresholds = [1]
         num_bits = 2
         quantizer = WeightsPOTInferableQuantizer(num_bits=num_bits,
                                                  per_channel=False,

--- a/tests/pytorch_tests/test_activation_quantizer_holder.py
+++ b/tests/pytorch_tests/test_activation_quantizer_holder.py
@@ -28,7 +28,7 @@ class TestPytorchActivationQuantizationHolderInference(unittest.TestCase):
 
     def test_activation_quantization_holder_inference(self):
         num_bits = 3
-        thresholds = np.array([4])
+        thresholds = [4]
         signed = True
 
         quantizer = ActivationSymmetricInferableQuantizer(num_bits=num_bits,
@@ -42,7 +42,7 @@ class TestPytorchActivationQuantizationHolderInference(unittest.TestCase):
         quantized_tensor = model(input_tensor)
 
         self.assertTrue(model.activation_holder_quantizer.num_bits == num_bits)
-        self.assertTrue(model.activation_holder_quantizer.threshold == thresholds)
+        self.assertTrue(model.activation_holder_quantizer.threshold_np == thresholds)
         self.assertTrue(model.activation_holder_quantizer.signed == signed)
 
 
@@ -57,7 +57,7 @@ class TestPytorchActivationQuantizationHolderInference(unittest.TestCase):
 
     def test_activation_quantization_holder_save_and_load(self):
         num_bits = 3
-        thresholds = np.array([4])
+        thresholds = [4]
         signed = True
 
         quantizer = ActivationPOTInferableQuantizer(num_bits=num_bits,

--- a/tests/pytorch_tests/test_pytorch_load_model.py
+++ b/tests/pytorch_tests/test_pytorch_load_model.py
@@ -64,7 +64,7 @@ class TestPytorchLoadModel(unittest.TestCase):
 
     def test_save_and_load_activation_pot(self):
         num_bits = 3
-        thresholds = np.asarray([4.])
+        thresholds = [4.]
         signed = True
         quantizer = ActivationPOTInferableQuantizer(num_bits=num_bits,
                                                     threshold=thresholds,
@@ -74,7 +74,7 @@ class TestPytorchLoadModel(unittest.TestCase):
 
     def test_save_and_load_activation_symmetric(self):
         num_bits = 3
-        thresholds = np.asarray([4.])
+        thresholds = [4.]
         signed = True
         quantizer = ActivationSymmetricInferableQuantizer(num_bits=num_bits,
                                                           threshold=thresholds,
@@ -84,8 +84,8 @@ class TestPytorchLoadModel(unittest.TestCase):
 
     def test_save_and_load_activation_uniform(self):
         num_bits = 3
-        min_range = np.asarray([1.])
-        max_range = np.asarray([4.])
+        min_range = [1.]
+        max_range = [4.]
         quantizer = ActivationUniformInferableQuantizer(num_bits=num_bits,
                                                         min_range=min_range,
                                                         max_range=max_range)
@@ -112,7 +112,7 @@ class TestPytorchLoadModel(unittest.TestCase):
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_weights_pot(self):
-        thresholds = np.asarray([4., 0.5, 2.])
+        thresholds = [4., 0.5, 2.]
         num_bits = 2
         quantizer = WeightsPOTInferableQuantizer(num_bits=num_bits,
                                                  per_channel=True,
@@ -123,7 +123,7 @@ class TestPytorchLoadModel(unittest.TestCase):
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_weights_symmetric(self):
-        thresholds = np.asarray([3., 6., 2.])
+        thresholds = [3., 6., 2.]
         num_bits = 2
         quantizer = WeightsSymmetricInferableQuantizer(num_bits=num_bits,
                                                        per_channel=True,


### PR DESCRIPTION
Add quantizers implementation to support ONNX export:
1. Add autograd function implementation for each quantizer to implement the op symbolic and forward static functions.
2. Add np implementation to support ops onnxruntime inference.

Change quantizers API to receive lists as their quantization range (instead of np arrays).