### PR TITLE
Fixes in quantizers API

### DIFF
--- a/mct_quantizers/common/constants.py
+++ b/mct_quantizers/common/constants.py
@@ -62,7 +62,7 @@ MIN_RANGE = 'min_range'
 MAX_RANGE = 'max_range'
 CHANNEL_AXIS = 'channel_axis'
 INPUT_RANK = 'input_rank'
-CLUSTER_CENTERS = 'cluster_centers'
+LUT_VALUES = 'lut_values'
 
 
 ## Constant values
@@ -71,4 +71,4 @@ LAYER = "layer"
 STEPS = "optimizer_step"
 TRAINING = "training"
 EPS = 1e-8
-MULTIPLIER_N_BITS = 8
+LUT_VALUES_BITWIDTH = 8

--- a/mct_quantizers/keras/quantizer_utils.py
+++ b/mct_quantizers/keras/quantizer_utils.py
@@ -18,38 +18,38 @@ import tensorflow as tf
 
 
 def lut_quantizer(tensor_data: tf.Tensor,
-                  cluster_centers: np.ndarray,
+                  lut_values: np.ndarray,
                   signed: bool,
                   threshold: np.ndarray,
-                  multiplier_n_bits: int,
+                  lut_values_bitwidth: int,
                   eps: float) -> tf.Tensor:
     """
-    Quantize a tensor using a non-uniform quantization based on the pre-defined clusters.
-    1. Scales tensor_data with the threshold into multiplier_n_bits quantization range.
-    2. Assigns cluster centers to each value.
+    Quantize a tensor using a non-uniform quantization based on the pre-defined values.
+    1. Scales tensor_data with the threshold into lut_values_bitwidth quantization range.
+    2. Assigns lut values to each value.
     3. Scales back by multiplying the result by threshold and dividing with the quantization range max value.
     The result is the quantized tensor.
 
     Args:
         tensor_data: Input activation tensor.
-        cluster_centers: the cluster centers to assign the tensor values.
+        lut_values: the values in the look-up table to assign the weights to
         signed: Whether the quantization is signed or not.
         threshold: threshold for quantization.
-        multiplier_n_bits: Number of bits that determines the quantization range
+        lut_values_bitwidth: Number of bits that determines the quantization range
         eps: Small value for numerical stability in division.
 
     Returns: Quantized tensor.
     """
 
-    tensor = int_quantization_with_threshold(tensor_data, n_bits=multiplier_n_bits, signed=signed, threshold=threshold,
+    tensor = int_quantization_with_threshold(tensor_data, n_bits=lut_values_bitwidth, signed=signed, threshold=threshold,
                                              eps=eps)
     tensor = tf.expand_dims(tensor, -1)
 
-    expanded_cluster_centers = cluster_centers.reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
-    cluster_assignments = tf.argmin(tf.abs(tensor - expanded_cluster_centers), axis=-1)
-    centers = tf.gather(cluster_centers.flatten(), cluster_assignments)
+    expanded_lut_values = lut_values.reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
+    lut_values_assignments = tf.argmin(tf.abs(tensor - expanded_lut_values), axis=-1)
+    centers = tf.gather(lut_values.flatten(), lut_values_assignments)
 
-    quant_tensor = (centers / (2 ** (multiplier_n_bits - int(signed)))) * threshold
+    quant_tensor = (centers / (2 ** (lut_values_bitwidth - int(signed)))) * threshold
 
     return quant_tensor
 

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
@@ -127,7 +127,7 @@ if FOUND_TF:
                                                f'{inputs.dtype}'
 
             return lut_quantizer(inputs,
-                                 lut_values=self._lut_values_as_np,
+                                 lut_values=self._lut_values_as_np.astype(np.float32),
                                  signed=self.signed,
                                  # In activation per-channel quantization is not supported
                                  # thus we expect a single threshold value. Assertion is made in init.

--- a/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
@@ -18,7 +18,7 @@ from typing import List
 import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
-from mct_quantizers.common.constants import FOUND_TF, MULTIPLIER_N_BITS, EPS
+from mct_quantizers.common.constants import FOUND_TF, LUT_VALUES_BITWIDTH, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.logger import Logger
 
@@ -38,20 +38,20 @@ if FOUND_TF:
 
         def __init__(self,
                      num_bits: int,
-                     cluster_centers: List[int],
+                     lut_values: List[int],
                      threshold: List[float],
                      signed: bool,
-                     multiplier_n_bits: int = MULTIPLIER_N_BITS,
+                     lut_values_bitwidth: int = LUT_VALUES_BITWIDTH,
                      eps: float = EPS):
             """
             Initialize the quantizer with the specified parameters.
 
             Args:
                 num_bits: number of bits to use for quantization
-                cluster_centers: the cluster centers to assign the activations
+                lut_values: the values in the look-up table to assign the weights to
                 threshold: threshold for quantizing activations
                 signed: whether or not to use signed quantization
-                multiplier_n_bits: Number of bits that determines the quantization range
+                lut_values_bitwidth: Number of bits that determines the quantization range
                 eps: Small value for numerical stability in division
             """
             # Call the superclass constructor with the given parameters, along with the target of Activation
@@ -72,45 +72,45 @@ if FOUND_TF:
 
             self.threshold = threshold
 
-            # Convert cluster_centers to numpy array for all assertions, and convert it back to list before saving.
+            # Convert lut_values to numpy array for all assertions, and convert it back to list before saving.
             # The reason for doing so is that during deserialization (when get_config is called) the returned value
-            # is a list (even if it was a numpy array during serialization) thus the expected cluster centers type
+            # is a list (even if it was a numpy array during serialization) thus the expected lut values type
             # must be a list. The conversion to numpy is to make assertions more clean.
-            cluster_centers = np.asarray(cluster_centers)
+            lut_values = np.asarray(lut_values)
 
-            assert len(np.unique(cluster_centers)) <= 2 ** num_bits, \
-                f'Expected num of cluster centers to be less or equal than {2 ** num_bits} ' \
-                f'but got {len(cluster_centers)}'
+            assert len(np.unique(lut_values)) <= 2 ** num_bits, \
+                f'Expected num of lut values to be less or equal than {2 ** num_bits} ' \
+                f'but got {len(lut_values)}'
 
-            assert not np.any(cluster_centers - cluster_centers.astype(int)), f'Expected cluster centers to be integers'
+            assert not np.any(lut_values - lut_values.astype(int)), f'Expected lut values to be integers'
 
             if signed:
-                assert np.all((-1 * (2 ** (multiplier_n_bits - int(signed))) <= cluster_centers) &
-                              (cluster_centers <= (2 ** (multiplier_n_bits - int(signed)) - 1))), \
-                    f'Expected cluster centers in the quantization range'
+                assert np.all((-1 * (2 ** (lut_values_bitwidth - int(signed))) <= lut_values) &
+                              (lut_values <= (2 ** (lut_values_bitwidth - int(signed)) - 1))), \
+                    f'Expected lut values in the quantization range'
             else:
-                assert np.all(cluster_centers <= (2 ** multiplier_n_bits)), \
-                    f'Expected cluster centers in the quantization range'
+                assert np.all(lut_values <= (2 ** lut_values_bitwidth)), \
+                    f'Expected lut values in the quantization range'
 
-            # num_bits must be less than multiplier_n_bits
-            assert num_bits <= multiplier_n_bits, f'Look-Up-Table bit configuration has {num_bits} bits. It must be ' \
-                                                  f'less then {multiplier_n_bits}'
-            if num_bits == multiplier_n_bits:
+            # num_bits must be less than lut_values_bitwidth
+            assert num_bits <= lut_values_bitwidth, f'Look-Up-Table bit configuration has {num_bits} bits. It must be ' \
+                                                  f'less then {lut_values_bitwidth}'
+            if num_bits == lut_values_bitwidth:
                 warnings.warn("Num of bits equal to multiplier n bits, Please be aware LUT quantizier may be "
                               "inefficient in that case, consider using SymmetricInferableQuantizer instead")
 
-            # If unsigned activation quantization, all cluster_centers must have the same sign
+            # If unsigned activation quantization, all lut_values must have the same sign
             if not signed:
-                assert np.all(cluster_centers >= 0), f'Expected unsigned cluster centers in unsigned activation ' \
+                assert np.all(lut_values >= 0), f'Expected unsigned lut values in unsigned activation ' \
                                                      f'quantization '
 
             self.num_bits = num_bits
             # Save as a numpy array to avoid conversion during inference
-            self._cluster_centers_as_np = cluster_centers
+            self._lut_values_as_np = lut_values
             # Save as a list for serialization purposes
-            self.cluster_centers = cluster_centers.tolist()
+            self.lut_values = lut_values.tolist()
             self.signed = signed
-            self.multiplier_n_bits = multiplier_n_bits
+            self.lut_values_bitwidth = lut_values_bitwidth
             self.eps = eps
 
         def __call__(self, inputs: tf.Tensor) -> tf.Tensor:
@@ -127,12 +127,12 @@ if FOUND_TF:
                                                f'{inputs.dtype}'
 
             return lut_quantizer(inputs,
-                                 cluster_centers=self._cluster_centers_as_np,
+                                 lut_values=self._lut_values_as_np,
                                  signed=self.signed,
                                  # In activation per-channel quantization is not supported
                                  # thus we expect a single threshold value. Assertion is made in init.
                                  threshold=self.threshold[0],
-                                 multiplier_n_bits=self.multiplier_n_bits,
+                                 lut_values_bitwidth=self.lut_values_bitwidth,
                                  eps=self.eps)
 
         def get_config(self):
@@ -140,14 +140,14 @@ if FOUND_TF:
             Return a dictionary with the configuration of the quantizer.
 
             Returns:
-                Dictionary with the following keys: 'num_bits', 'cluster_centers', 'threshold', 'signed',
-                'multiplier_n_bits', 'eps'
+                Dictionary with the following keys: 'num_bits', 'lut_values', 'threshold', 'signed',
+                'lut_values_bitwidth', 'eps'
             """
             return {'num_bits': self.num_bits,
-                    'cluster_centers': self.cluster_centers,
+                    'lut_values': self.lut_values,
                     'threshold': self.threshold,
                     'signed': self.signed,
-                    'multiplier_n_bits': self.multiplier_n_bits,
+                    'lut_values_bitwidth': self.lut_values_bitwidth,
                     'eps': self.eps}
 
 

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
@@ -17,7 +17,7 @@ from typing import List
 import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
-from mct_quantizers.common.constants import FOUND_TF, MULTIPLIER_N_BITS, EPS
+from mct_quantizers.common.constants import FOUND_TF, LUT_VALUES_BITWIDTH, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
 
@@ -36,34 +36,34 @@ if FOUND_TF:
 
         def __init__(self,
                      num_bits: int,
-                     cluster_centers: List[float],
+                     lut_values: List[float],
                      threshold: List[float],
                      per_channel: bool,
                      channel_axis: int = None,
                      input_rank: int = None,
-                     multiplier_n_bits: int = MULTIPLIER_N_BITS,
+                     lut_values_bitwidth: int = LUT_VALUES_BITWIDTH,
                      eps: float = EPS):
             """
             Initialize the quantizer with the specified parameters.
 
             Args:
                 num_bits: number of bits to use for quantization
-                cluster_centers: the cluster centers to assign the weights
+                lut_values: the values in the look-up table to assign the weights to
                 threshold: threshold for quantizing weights
                 per_channel: whether to use per-channel quantization
                 channel_axis: axis along which to apply per-channel quantization
                 input_rank: number of dimensions of input tensor the quantizer quantizes
-                multiplier_n_bits: Number of bits that determines the quantization range
+                lut_values_bitwidth: Number of bits that determines the quantization range
                 eps: Small value for numerical stability in division
             """
 
             super(WeightsLUTPOTInferableQuantizer, self).__init__(num_bits=num_bits,
-                                                                  cluster_centers=cluster_centers,
+                                                                  lut_values=lut_values,
                                                                   threshold=threshold,
                                                                   per_channel=per_channel,
                                                                   channel_axis=channel_axis,
                                                                   input_rank=input_rank,
-                                                                  multiplier_n_bits=multiplier_n_bits,
+                                                                  lut_values_bitwidth=lut_values_bitwidth,
                                                                   eps=eps)
 
             is_threshold_pot = np.all([int(np.log2(x)) == np.log2(x) for x in self._np_threshold.flatten()])

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
@@ -142,7 +142,7 @@ if FOUND_TF:
 
                 # Quantize the input tensor using per-channel quantization
                 q_tensor = lut_quantizer(inputs,
-                                         lut_values=self._np_lut_values,
+                                         lut_values=self._np_lut_values.astype(np.float32),
                                          signed=True,
                                          threshold=self._np_threshold,
                                          lut_values_bitwidth=self.lut_values_bitwidth,

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -30,10 +30,10 @@ if FOUND_TF:
                     identifier=QuantizerID.INFERABLE)
     class WeightsPOTInferableQuantizer(WeightsSymmetricInferableQuantizer):
         """
-        Class for quantizing weights using unsigned power-of-two quantizer.
+        Class for quantizing weights using a power-of-two quantizer.
         """
 
-        def __init__(self,
+        def __init__unsigned(self,
                      num_bits: int,
                      threshold: List[float],
                      per_channel: bool,

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -33,7 +33,7 @@ if FOUND_TF:
         Class for quantizing weights using a power-of-two quantizer.
         """
 
-        def __init__unsigned(self,
+        def __init__(self,
                      num_bits: int,
                      threshold: List[float],
                      per_channel: bool,

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -30,7 +30,7 @@ if FOUND_TF:
                     identifier=QuantizerID.INFERABLE)
     class WeightsSymmetricInferableQuantizer(WeightsUniformInferableQuantizer):
         """
-        Class for quantizing weights using unsigned symmetric quantizer.
+        Class for quantizing weights using a symmetric quantizer.
         """
         def __init__(self,
                      num_bits: int,
@@ -78,6 +78,16 @@ if FOUND_TF:
                     'per_channel': self.per_channel,
                     'channel_axis': self.channel_axis,
                     'input_rank': self.input_rank}
+
+        @property
+        def signed(self) -> bool:
+            """
+            Property to indicates that symmetric weights quantization is always signed.
+
+            Returns: True by definition.
+
+            """
+            return True
 
 else:
     class WeightsSymmetricInferableQuantizer:  # pragma: no cover

--- a/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/keras/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -33,7 +33,7 @@ if FOUND_TF:
                     identifier=QuantizerID.INFERABLE)
     class WeightsUniformInferableQuantizer(BaseKerasInferableQuantizer):
         """
-        Class for quantizing weights using unsigned uniform quantizer
+        Class for quantizing weights using a uniform quantizer
         """
         def __init__(self,
                      num_bits: int,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
@@ -16,7 +16,7 @@
 import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
-from mct_quantizers.common.constants import FOUND_TORCH, MULTIPLIER_N_BITS, EPS
+from mct_quantizers.common.constants import FOUND_TORCH, LUT_VALUES_BITWIDTH, EPS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
 
@@ -34,31 +34,31 @@ if FOUND_TORCH:
 
         def __init__(self,
                      num_bits: int,
-                     cluster_centers: np.ndarray,
+                     lut_values: np.ndarray,
                      threshold: np.ndarray,
                      per_channel: bool,
                      channel_axis: int = None,
-                     multiplier_n_bits: int = MULTIPLIER_N_BITS,
+                     lut_values_bitwidth: int = LUT_VALUES_BITWIDTH,
                      eps: float = EPS):
             """
             Initialize the quantizer with the specified parameters.
 
             Args:
                 num_bits: number of bits to use for quantization
-                cluster_centers: the cluster centers to assign the weights
+                lut_values: the values in the look-up table to assign the weights to
                 threshold: threshold for quantizing weights
                 per_channel: whether to use per-channel quantization
                 channel_axis: Axis of input to apply per-channel quantization on
-                multiplier_n_bits: Number of bits that determines the quantization range
+                lut_values_bitwidth: Number of bits that determines the quantization range
                 eps: Small value for numerical stability in division
             """
             # target of Weights quantization
             super(WeightsLUTPOTInferableQuantizer, self).__init__(num_bits=num_bits,
                                                                   threshold=threshold,
-                                                                  cluster_centers=cluster_centers,
+                                                                  lut_values=lut_values,
                                                                   per_channel=per_channel,
                                                                   channel_axis=channel_axis,
-                                                                  multiplier_n_bits=multiplier_n_bits,
+                                                                  lut_values_bitwidth=lut_values_bitwidth,
                                                                   eps=eps)
 
             is_threshold_pot = np.all(np.round(np.log2(threshold.flatten())) == np.log2(threshold.flatten()))

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -29,7 +29,7 @@ if FOUND_TORCH:
                     identifier=QuantizerID.INFERABLE)
     class WeightsPOTInferableQuantizer(WeightsSymmetricInferableQuantizer):
         """
-        Class for quantizing weights using unsigned power-of-two quantizer.
+        Class for quantizing weights using a power-of-two quantizer.
         """
 
         def __init__(self,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -30,7 +30,7 @@ if FOUND_TORCH:
                     identifier=QuantizerID.INFERABLE)
     class WeightsSymmetricInferableQuantizer(BaseSymmetricInferableQuantizer):
         """
-        Class for quantizing weights using unsigned symmetric quantizer.
+        Class for quantizing weights using a symmetric quantizer.
         """
 
         def __init__(self,

--- a/tests/keras_tests/quantizers_tests/test_activation_lut_pot_inferable_quantizer.py
+++ b/tests/keras_tests/quantizers_tests/test_activation_lut_pot_inferable_quantizer.py
@@ -24,7 +24,7 @@ from mct_quantizers.keras.quantizers.activation_inferable_quantizers.activation_
 class TestKerasActivationLutPotQuantizer(unittest.TestCase):
 
     def test_lut_pot_signed_quantizer(self):
-        lut_values = np.asarray([-25, 25])
+        lut_values = np.asarray([-25, 25], dtype=np.float32)
         thresholds = [4.]
         num_bits = 3
         signed = True
@@ -95,7 +95,7 @@ class TestKerasActivationLutPotQuantizer(unittest.TestCase):
                         f'Expected some values to be negative but quantized tensor is {quantized_tensor}')
 
     def test_lut_pot_unsigned_quantizer(self):
-        lut_values = np.asarray([25, 85])
+        lut_values = np.asarray([25, 85], dtype=np.float32)
         thresholds = [2.]
         num_bits = 3
         signed = False

--- a/tests/keras_tests/quantizers_tests/test_illegal_activation_lut_pot_inferable_quantizer.py
+++ b/tests/keras_tests/quantizers_tests/test_illegal_activation_lut_pot_inferable_quantizer.py
@@ -27,56 +27,56 @@ class TestKerasActivationIllegalLutPotQuantizer(unittest.TestCase):
     def test_illegal_pot_lut_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               cluster_centers=np.asarray([25., 85.]),
+                                               lut_values=np.asarray([25., 85.]),
                                                threshold=[3.],
                                                signed=True)
         self.assertEqual('Expected threshold to be power of 2 but is [3.0]', str(e.exception))
 
-    def test_illegal_cluster_centers(self):
+    def test_illegal_lut_values(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               cluster_centers=np.asarray([25.9, 85.]),
+                                               lut_values=np.asarray([25.9, 85.]),
                                                threshold=[4.],
                                                signed=True)
-        self.assertEqual('Expected cluster centers to be integers', str(e.exception))
+        self.assertEqual('Expected lut values to be integers', str(e.exception))
 
-    def test_illegal_num_of_cluster_centers(self):
-        cluster_centers = np.asarray([-25, 25, 12, 45, 11])
+    def test_illegal_num_of_lut_values(self):
+        lut_values = np.asarray([-25, 25, 12, 45, 11])
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=2,
-                                               cluster_centers=cluster_centers,
+                                               lut_values=lut_values,
                                                threshold=[4.],
                                                signed=True)
         self.assertEqual(
-            f'Expected num of cluster centers to be less or equal than {2 ** 2} but got '
-            f'{len(cluster_centers)}', str(e.exception))
+            f'Expected num of lut values to be less or equal than {2 ** 2} but got '
+            f'{len(lut_values)}', str(e.exception))
 
-    def test_illegal_cluster_centers_range_(self):
+    def test_illegal_lut_values_range_(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=2,
-                                               cluster_centers=np.asarray([50]),
+                                               lut_values=np.asarray([50]),
                                                threshold=[4.],
                                                signed=True,
-                                               multiplier_n_bits=3)
-        self.assertEqual('Expected cluster centers in the quantization range', str(e.exception))
+                                               lut_values_bitwidth=3)
+        self.assertEqual('Expected lut values in the quantization range', str(e.exception))
 
-    def test_illegal_num_bit_bigger_than_multiplier_n_bits(self):
+    def test_illegal_num_bit_bigger_than_lut_values_bitwidth(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=10,
-                                               cluster_centers=np.asarray([25]),
+                                               lut_values=np.asarray([25]),
                                                threshold=[4.],
                                                signed=True,
-                                               multiplier_n_bits=8)
+                                               lut_values_bitwidth=8)
         self.assertEqual('Look-Up-Table bit configuration has 10 bits. It must be less then 8'
                                              , str(e.exception))
 
-    def test_warning_num_bit_equal_multiplier_n_bits(self):
+    def test_warning_num_bit_equal_lut_values_bitwidth(self):
         with warnings.catch_warnings(record=True) as w:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               cluster_centers=np.asarray([25]),
+                                               lut_values=np.asarray([25]),
                                                threshold=[4.],
                                                signed=True,
-                                               multiplier_n_bits=8)
+                                               lut_values_bitwidth=8)
         self.assertTrue(
             'Num of bits equal to multiplier n bits, Please be aware LUT quantizier may be inefficient '
             'in that case, consider using SymmetricInferableQuantizer instead'
@@ -85,28 +85,28 @@ class TestKerasActivationIllegalLutPotQuantizer(unittest.TestCase):
     def test_illegal_num_of_thresholds(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=3,
-                                               cluster_centers=np.asarray([25]),
+                                               lut_values=np.asarray([25]),
                                                threshold=[4., 2.],
                                                signed=True,
-                                               multiplier_n_bits=8)
+                                               lut_values_bitwidth=8)
         self.assertEqual('In per-tensor quantization threshold should be of length 1 but is 2',
                                              str(e.exception))
 
     def test_illegal_threshold_type(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=3,
-                                               cluster_centers=np.asarray([25]),
+                                               lut_values=np.asarray([25]),
                                                threshold=np.asarray([4.]),
                                                signed=True,
-                                               multiplier_n_bits=8)
+                                               lut_values_bitwidth=8)
             self.assertEqual(
                 'Expected threshold to be of type list but is <class \'numpy.ndarray\'>', str(e.exception))
 
-    def test_illegal_signed_cluster_centers(self):
+    def test_illegal_signed_lut_values(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               cluster_centers=np.asarray([-25., 85.]),
+                                               lut_values=np.asarray([-25., 85.]),
                                                threshold=[2.],
                                                signed=False)
-        self.assertEqual('Expected unsigned cluster centers in unsigned activation quantization ',
+        self.assertEqual('Expected unsigned lut values in unsigned activation quantization ',
                                              str(e.exception))

--- a/tests/keras_tests/quantizers_tests/test_illegal_weights_lut_inferable_quantizer.py
+++ b/tests/keras_tests/quantizers_tests/test_illegal_weights_lut_inferable_quantizer.py
@@ -26,140 +26,140 @@ from mct_quantizers.keras.quantizers.weights_inferable_quantizers.weights_lut_sy
 
 class BaseKerasWeightsIllegalLutQuantizerTest(unittest.TestCase):
 
-    def illegal_cluster_centers_inferable_quantizer_test(self, inferable_quantizer, threshold, cluster_centers,
+    def illegal_lut_values_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
                                                          per_channel, input_rank, channel_axis):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis,
                                 input_rank=input_rank)
-        self.assertEqual('Expected cluster centers to be integers', str(e.exception))
+        self.assertEqual('Expected lut values to be integers', str(e.exception))
 
-    def illegal_num_of_cluster_centers_inferable_quantizer_test(self, inferable_quantizer, threshold, cluster_centers,
+    def illegal_num_of_lut_values_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
                                                                 per_channel, input_rank, channel_axis):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=2,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis,
                                 input_rank=input_rank)
-        self.assertEqual(f'Expected num of cluster centers to be less or equal than {2 ** 2} but got '
-                                   f'{len(cluster_centers)}', str(e.exception))
+        self.assertEqual(f'Expected num of lut values to be less or equal than {2 ** 2} but got '
+                                   f'{len(lut_values)}', str(e.exception))
 
-    def illegal_cluster_centers_range_inferable_quantizer_test(self, inferable_quantizer, threshold, cluster_centers,
+    def illegal_lut_values_range_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
                                                                per_channel, input_rank, channel_axis,
-                                                               multiplier_n_bits):
+                                                               lut_values_bitwidth):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis,
-                                multiplier_n_bits=multiplier_n_bits,
+                                lut_values_bitwidth=lut_values_bitwidth,
                                 input_rank=input_rank)
-        self.assertEqual('Expected cluster centers in the quantization range', str(e.exception))
+        self.assertEqual('Expected lut values in the quantization range', str(e.exception))
 
-    def illegal_num_bit_bigger_than_multiplier_n_bits_inferable_quantizer_test(self, inferable_quantizer, threshold,
-                                                                               cluster_centers,
+    def illegal_num_bit_bigger_than_lut_values_bitwidth_inferable_quantizer_test(self, inferable_quantizer, threshold,
+                                                                               lut_values,
                                                                                num_bits, input_rank,
                                                                                per_channel, channel_axis,
-                                                                               multiplier_n_bits):
+                                                                               lut_values_bitwidth):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=num_bits,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis,
-                                multiplier_n_bits=multiplier_n_bits,
+                                lut_values_bitwidth=lut_values_bitwidth,
                                 input_rank=input_rank)
         self.assertEqual('Look-Up-Table bit configuration has 10 bits. It must be less then 8'
                                    , str(e.exception))
 
-    def warning_num_bit_equal_multiplier_n_bits_inferable_quantizer_test(self, inferable_quantizer, threshold,
-                                                                         cluster_centers,
+    def warning_num_bit_equal_lut_values_bitwidth_inferable_quantizer_test(self, inferable_quantizer, threshold,
+                                                                         lut_values,
                                                                          num_bits, input_rank,
                                                                          per_channel, channel_axis,
-                                                                         multiplier_n_bits):
+                                                                         lut_values_bitwidth):
         with warnings.catch_warnings(record=True) as w:
             inferable_quantizer(num_bits=num_bits,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis,
-                                multiplier_n_bits=multiplier_n_bits,
+                                lut_values_bitwidth=lut_values_bitwidth,
                                 input_rank=input_rank)
         self.assertTrue(
             'Num of bits equal to multiplier n bits, Please be aware LUT quantizier may be inefficient '
             'in that case, consider using SymmetricInferableQuantizer instead'
             in [str(warning.message) for warning in w])
 
-    def illegal_num_of_thresholds_inferable_quantizer_test(self, inferable_quantizer, threshold, cluster_centers,
+    def illegal_num_of_thresholds_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
                                                            per_channel, channel_axis, input_rank):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis,
                                 input_rank=input_rank)
         self.assertEqual('In per-tensor quantization threshold should be of length 1 but is 2',
                                    str(e.exception))
 
-    def illegal_threshold_type_inferable_quantizer_test(self, inferable_quantizer, threshold, cluster_centers,
+    def illegal_threshold_type_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
                                                         per_channel, channel_axis, input_rank):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis,
                                 input_rank=input_rank)
         self.assertEqual('Expected threshold to be of type list but is <class \'numpy.ndarray\'>',
                                    str(e.exception))
 
-    def missing_channel_axis_inferable_quantizer(self, inferable_quantizer, threshold, cluster_centers,
+    def missing_channel_axis_inferable_quantizer(self, inferable_quantizer, threshold, lut_values,
                                                  per_channel, input_rank):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 input_rank=input_rank)
         self.assertEqual('Channel axis is missing in per channel quantization', str(e.exception))
 
-    def missing_input_rank_inferable_quantizer(self, inferable_quantizer, threshold, cluster_centers,
+    def missing_input_rank_inferable_quantizer(self, inferable_quantizer, threshold, lut_values,
                                                per_channel, channel_axis):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis)
         self.assertEqual('Input rank is missing in per channel quantization', str(e.exception))
 
-    def weights_inferable_quantizer_test(self, inferable_quantizer, num_bits, threshold, cluster_centers,
-                                         per_channel, channel_axis, input_rank, multiplier_n_bits, eps):
+    def weights_inferable_quantizer_test(self, inferable_quantizer, num_bits, threshold, lut_values,
+                                         per_channel, channel_axis, input_rank, lut_values_bitwidth, eps):
         quantizer = inferable_quantizer(num_bits=num_bits,
                                         per_channel=per_channel,
-                                        cluster_centers=cluster_centers,
+                                        lut_values=lut_values,
                                         threshold=threshold,
                                         channel_axis=channel_axis,
                                         input_rank=input_rank,
-                                        multiplier_n_bits=multiplier_n_bits,
+                                        lut_values_bitwidth=lut_values_bitwidth,
                                         eps=eps)
 
         # check config
         quantizer_config = quantizer.get_config()
         self.assertTrue(quantizer_config['num_bits'] == num_bits)
         self.assertTrue(np.all(quantizer_config['threshold'] == np.asarray(threshold)))
-        self.assertTrue(np.all(quantizer_config['cluster_centers'] == cluster_centers))
+        self.assertTrue(np.all(quantizer_config['lut_values'] == lut_values))
         self.assertTrue(quantizer_config['per_channel'] == per_channel)
         self.assertTrue(quantizer_config['channel_axis'] == channel_axis)
         self.assertTrue(quantizer_config['input_rank'] == input_rank)
-        self.assertTrue(quantizer_config['multiplier_n_bits'] == multiplier_n_bits)
+        self.assertTrue(quantizer_config['lut_values_bitwidth'] == lut_values_bitwidth)
         self.assertTrue(quantizer_config['eps'] == eps)
 
         # test permute
@@ -189,7 +189,7 @@ class BaseKerasWeightsIllegalLutQuantizerTest(unittest.TestCase):
         # and abs(max(threshold))
 
         max_threshold = np.max(np.abs(threshold))
-        delta_threshold = 1 / (2 ** (multiplier_n_bits - 1))
+        delta_threshold = 1 / (2 ** (lut_values_bitwidth - 1))
 
         self.assertTrue(np.max(
             quantized_tensor) <= max_threshold - delta_threshold, f'Quantized values should not contain values greater '
@@ -203,13 +203,13 @@ class BaseKerasWeightsIllegalLutQuantizerTest(unittest.TestCase):
                                   f'{len(np.unique(quantized_tensor))} unique values')
 
         # Check quantized tensor assigned correctly
-        clip_max = 2 ** (multiplier_n_bits - 1) - 1
-        clip_min = -2 ** (multiplier_n_bits - 1)
+        clip_max = 2 ** (lut_values_bitwidth - 1) - 1
+        clip_min = -2 ** (lut_values_bitwidth - 1)
 
         if per_channel:
             for i in range(len(threshold)):
                 channel_slice_i = quantized_tensor[:, :, :, i]
-                channel_quant_tensor_values = cluster_centers / (2 ** (multiplier_n_bits - 1)) * threshold[i]
+                channel_quant_tensor_values = lut_values / (2 ** (lut_values_bitwidth - 1)) * threshold[i]
                 self.assertTrue(len(np.unique(channel_slice_i)) <= 2 ** num_bits,
                                           f'Quantized tensor expected to have no more than {2 ** num_bits} unique values but has '
                                           f'{len(np.unique(channel_slice_i))} unique values')
@@ -219,15 +219,15 @@ class BaseKerasWeightsIllegalLutQuantizerTest(unittest.TestCase):
                 tensor = tf.clip_by_value((input_tensor / (threshold[i] + eps)) * (2 ** (num_bits - 1)),
                                           clip_value_max=clip_max, clip_value_min=clip_min)
                 tensor = tf.expand_dims(tf.transpose(tensor, perm=perm_vec)[:, :, :, i], -1)
-                expanded_cluster_centers = cluster_centers.reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
-                cluster_assignments = tf.argmin(tf.abs(tensor - expanded_cluster_centers), axis=-1)
-                centers = tf.gather(cluster_centers.flatten(), cluster_assignments)
+                expanded_lut_values = lut_values.reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
+                lut_values_assignments = tf.argmin(tf.abs(tensor - expanded_lut_values), axis=-1)
+                centers = tf.gather(lut_values.flatten(), lut_values_assignments)
 
                 self.assertTrue(
-                    np.all(centers / (2 ** (multiplier_n_bits - 1)) * threshold[i] == channel_slice_i),
+                    np.all(centers / (2 ** (lut_values_bitwidth - 1)) * threshold[i] == channel_slice_i),
                     "Quantized tensor values weren't assigned correctly")
         else:
-            quant_tensor_values = cluster_centers / (2 ** (multiplier_n_bits - 1)) * threshold
+            quant_tensor_values = lut_values / (2 ** (lut_values_bitwidth - 1)) * threshold
             self.assertTrue(len(np.unique(quantized_tensor)) <= 2 ** num_bits,
                                       f'Quantized tensor expected to have no more than {2 ** num_bits} unique values but has '
                                       f'{len(np.unique(quantized_tensor))} unique values')
@@ -237,12 +237,12 @@ class BaseKerasWeightsIllegalLutQuantizerTest(unittest.TestCase):
             tensor = tf.clip_by_value((input_tensor / (threshold[0] + eps)) * (2 ** (num_bits - 1)),
                                       clip_value_max=clip_max, clip_value_min=clip_min)
             tensor = tf.expand_dims(tensor, -1)
-            expanded_cluster_centers = cluster_centers.reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
-            cluster_assignments = tf.argmin(tf.abs(tensor - expanded_cluster_centers), axis=-1)
-            centers = tf.gather(cluster_centers.flatten(), cluster_assignments)
+            expanded_lut_values = lut_values.reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
+            lut_values_assignments = tf.argmin(tf.abs(tensor - expanded_lut_values), axis=-1)
+            centers = tf.gather(lut_values.flatten(), lut_values_assignments)
 
             self.assertTrue(
-                np.all(centers / (2 ** (multiplier_n_bits - 1)) * threshold[0] == quantized_tensor),
+                np.all(centers / (2 ** (lut_values_bitwidth - 1)) * threshold[0] == quantized_tensor),
                 "Quantized tensor values weren't assigned correctly")
 
         # Assert some values are negative (signed quantization)
@@ -257,57 +257,57 @@ class TestKerasWeightsIllegalSymmetricLutQuantizer(BaseKerasWeightsIllegalLutQua
 
         self.inferable_quantizer = WeightsLUTSymmetricInferableQuantizer
 
-    def test_illegal_cluster_centers_symmetric_lut_quantizer(self):
-        self.illegal_cluster_centers_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_lut_values_symmetric_lut_quantizer(self):
+        self.illegal_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                               threshold=[2.],
-                                                              cluster_centers=np.asarray([-25.6, 25]),
+                                                              lut_values=np.asarray([-25.6, 25]),
                                                               per_channel=False,
                                                               channel_axis=None,
                                                               input_rank=4)
 
-    def test_illegal_num_of_cluster_centers_symmetric_lut_quantizer(self):
-        self.illegal_num_of_cluster_centers_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_num_of_lut_values_symmetric_lut_quantizer(self):
+        self.illegal_num_of_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                      threshold=[2.],
-                                                                     cluster_centers=np.asarray([-25, 25, 3, 19, 55]),
+                                                                     lut_values=np.asarray([-25, 25, 3, 19, 55]),
                                                                      per_channel=False,
                                                                      channel_axis=None,
                                                                      input_rank=4)
 
-    def test_illegal_cluster_centers_range_symmetric_lut_quantizer(self):
-        self.illegal_cluster_centers_range_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_lut_values_range_symmetric_lut_quantizer(self):
+        self.illegal_lut_values_range_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                     threshold=[2.],
-                                                                    cluster_centers=np.asarray([-25, 25]),
+                                                                    lut_values=np.asarray([-25, 25]),
                                                                     per_channel=False,
                                                                     channel_axis=None,
-                                                                    multiplier_n_bits=5,
+                                                                    lut_values_bitwidth=5,
                                                                     input_rank=4)
 
-    def test_illegal_num_bit_bigger_than_multiplier_n_bits_symmetric_lut_quantizer(self):
-        self.illegal_num_bit_bigger_than_multiplier_n_bits_inferable_quantizer_test(
+    def test_illegal_num_bit_bigger_than_lut_values_bitwidth_symmetric_lut_quantizer(self):
+        self.illegal_num_bit_bigger_than_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
             threshold=[2.],
-            cluster_centers=np.asarray([-25, 25]),
+            lut_values=np.asarray([-25, 25]),
             per_channel=False,
             channel_axis=None,
-            multiplier_n_bits=8,
+            lut_values_bitwidth=8,
             num_bits=10,
             input_rank=4)
 
-    def test_warning_num_bit_equal_multiplier_n_bits_symmetric_lut_quantizer(self):
-        self.warning_num_bit_equal_multiplier_n_bits_inferable_quantizer_test(
+    def test_warning_num_bit_equal_lut_values_bitwidth_symmetric_lut_quantizer(self):
+        self.warning_num_bit_equal_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
             threshold=[2.],
-            cluster_centers=np.asarray([-25, 25]),
+            lut_values=np.asarray([-25, 25]),
             per_channel=False,
             channel_axis=None,
-            multiplier_n_bits=8,
+            lut_values_bitwidth=8,
             num_bits=8,
             input_rank=4)
 
     def test_illegal_threshold_type_symmetric_lut_quantizer(self):
         self.illegal_threshold_type_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                              threshold=np.asarray([3., 2.]),
-                                                             cluster_centers=np.asarray([-25, 25]),
+                                                             lut_values=np.asarray([-25, 25]),
                                                              per_channel=False,
                                                              channel_axis=None,
                                                              input_rank=4)
@@ -315,7 +315,7 @@ class TestKerasWeightsIllegalSymmetricLutQuantizer(BaseKerasWeightsIllegalLutQua
     def test_illegal_num_of_thresholds_symmetric_lut_quantizer(self):
         self.illegal_num_of_thresholds_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                 threshold=[2., 7.],
-                                                                cluster_centers=np.asarray([-25, 25]),
+                                                                lut_values=np.asarray([-25, 25]),
                                                                 per_channel=False,
                                                                 channel_axis=None,
                                                                 input_rank=4)
@@ -323,14 +323,14 @@ class TestKerasWeightsIllegalSymmetricLutQuantizer(BaseKerasWeightsIllegalLutQua
     def test_missing_channel_axis_symmetric_lut_quantizer(self):
         self.missing_channel_axis_inferable_quantizer(inferable_quantizer=self.inferable_quantizer,
                                                       threshold=[2.],
-                                                      cluster_centers=np.asarray([-25, 25]),
+                                                      lut_values=np.asarray([-25, 25]),
                                                       per_channel=True,
                                                       input_rank=4)
 
     def test_missing_input_rank_symmetric_lut_quantizer(self):
         self.missing_input_rank_inferable_quantizer(inferable_quantizer=self.inferable_quantizer,
                                                     threshold=[2.],
-                                                    cluster_centers=np.asarray([-25, 25]),
+                                                    lut_values=np.asarray([-25, 25]),
                                                     channel_axis=None,
                                                     per_channel=True)
 
@@ -347,63 +347,63 @@ class TestKerasWeightsIllegalPotLutQuantizer(BaseKerasWeightsIllegalLutQuantizer
         with self.assertRaises(Exception) as e:
             self.inferable_quantizer(num_bits=8,
                                      per_channel=False,
-                                     cluster_centers=[25., 85.],
+                                     lut_values=[25., 85.],
                                      threshold=[3.],
                                      channel_axis=None,
                                      input_rank=4)
         self.assertEqual('Expected threshold to be power of 2 but is [3.]', str(e.exception))
 
-    def test_illegal_cluster_centers_pot_lut_quantizer(self):
-        self.illegal_cluster_centers_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_lut_values_pot_lut_quantizer(self):
+        self.illegal_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                               threshold=[2.],
-                                                              cluster_centers=np.asarray([-25.6, 25]),
+                                                              lut_values=np.asarray([-25.6, 25]),
                                                               per_channel=False,
                                                               channel_axis=None,
                                                               input_rank=4)
 
-    def test_illegal_num_of_cluster_centers_pot_lut_quantizer(self):
-        self.illegal_num_of_cluster_centers_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_num_of_lut_values_pot_lut_quantizer(self):
+        self.illegal_num_of_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                      threshold=[2.],
-                                                                     cluster_centers=np.asarray([-25, 25, 3, 19, 55]),
+                                                                     lut_values=np.asarray([-25, 25, 3, 19, 55]),
                                                                      per_channel=False,
                                                                      channel_axis=None,
                                                                      input_rank=4)
 
-    def test_illegal_cluster_centers_range_pot_lut_quantizer(self):
-        self.illegal_cluster_centers_range_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_lut_values_range_pot_lut_quantizer(self):
+        self.illegal_lut_values_range_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                     threshold=[2.],
-                                                                    cluster_centers=np.asarray([-25, 25]),
+                                                                    lut_values=np.asarray([-25, 25]),
                                                                     per_channel=False,
                                                                     channel_axis=None,
                                                                     input_rank=4,
-                                                                    multiplier_n_bits=5)
+                                                                    lut_values_bitwidth=5)
 
-    def test_illegal_num_bit_bigger_than_multiplier_n_bits_pot_lut_quantizer(self):
-        self.illegal_num_bit_bigger_than_multiplier_n_bits_inferable_quantizer_test(
+    def test_illegal_num_bit_bigger_than_lut_values_bitwidth_pot_lut_quantizer(self):
+        self.illegal_num_bit_bigger_than_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
             threshold=[2.],
-            cluster_centers=np.asarray([-25, 25]),
+            lut_values=np.asarray([-25, 25]),
             per_channel=False,
             channel_axis=None,
             input_rank=4,
-            multiplier_n_bits=8,
+            lut_values_bitwidth=8,
             num_bits=10)
 
-    def test_warning_num_bit_equal_multiplier_n_bits_pot_lut_quantizer(self):
-        self.warning_num_bit_equal_multiplier_n_bits_inferable_quantizer_test(
+    def test_warning_num_bit_equal_lut_values_bitwidth_pot_lut_quantizer(self):
+        self.warning_num_bit_equal_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
             threshold=[2.],
-            cluster_centers=[-25, 25],
+            lut_values=[-25, 25],
             per_channel=False,
             channel_axis=None,
             input_rank=4,
-            multiplier_n_bits=8,
+            lut_values_bitwidth=8,
             num_bits=8)
 
     def test_illegal_threshold_type_pot_lut_quantizer(self):
         self.illegal_threshold_type_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                              threshold=np.asarray([2., 16.]),
-                                                             cluster_centers=np.asarray([-25, 25]),
+                                                             lut_values=np.asarray([-25, 25]),
                                                              per_channel=False,
                                                              channel_axis=None,
                                                              input_rank=4)
@@ -411,7 +411,7 @@ class TestKerasWeightsIllegalPotLutQuantizer(BaseKerasWeightsIllegalLutQuantizer
     def test_illegal_num_of_thresholds_pot_lut_quantizer(self):
         self.illegal_num_of_thresholds_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                 threshold=[2., 8.],
-                                                                cluster_centers=np.asarray([-25, 25]),
+                                                                lut_values=np.asarray([-25, 25]),
                                                                 per_channel=False,
                                                                 channel_axis=None,
                                                                 input_rank=4)
@@ -419,13 +419,13 @@ class TestKerasWeightsIllegalPotLutQuantizer(BaseKerasWeightsIllegalLutQuantizer
     def test_missing_channel_axis_pot_lut_quantizer(self):
         self.missing_channel_axis_inferable_quantizer(inferable_quantizer=self.inferable_quantizer,
                                                       threshold=[2.],
-                                                      cluster_centers=np.asarray([-25, 25]),
+                                                      lut_values=np.asarray([-25, 25]),
                                                       per_channel=True,
                                                       input_rank=4)
 
     def test_missing_input_rank_pot_lut_quantizer(self):
         self.missing_input_rank_inferable_quantizer(inferable_quantizer=self.inferable_quantizer,
                                                     threshold=[2.],
-                                                    cluster_centers=np.asarray([-25, 25]),
+                                                    lut_values=np.asarray([-25, 25]),
                                                     channel_axis=None,
                                                     per_channel=True)

--- a/tests/keras_tests/test_keras_load_model.py
+++ b/tests/keras_tests/test_keras_load_model.py
@@ -90,19 +90,19 @@ class TestKerasLoadModel(unittest.TestCase):
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_activation_lut_pot(self):
-        cluster_centers = [-25, 25]
+        lut_values = [-25, 25]
         thresholds = [4.]
         num_bits = 3
         signed = True
-        multiplier_n_bits = 8
+        lut_values_bitwidth = 8
         eps = 1e-8
 
         quantizer = ActivationLutPOTInferableQuantizer(num_bits=num_bits,
-                                                       cluster_centers=cluster_centers,
+                                                       lut_values=lut_values,
                                                        signed=signed,
                                                        threshold=thresholds,
-                                                       multiplier_n_bits=
-                                                       multiplier_n_bits,
+                                                       lut_values_bitwidth=
+                                                       lut_values_bitwidth,
                                                        eps=eps)
 
         layer_with_quantizer = KerasActivationQuantizationHolder(quantizer)
@@ -147,21 +147,21 @@ class TestKerasLoadModel(unittest.TestCase):
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_weights_lut_symmetric(self):
-        cluster_centers = [-25, 25]
+        lut_values = [-25, 25]
         per_channel = True
         input_rank = 4
         num_bits = 8
         threshold = [3., 8., 7.]
         channel_axis = 3
-        multiplier_n_bits = 8
+        lut_values_bitwidth = 8
         eps = 1e-8
         quantizer = WeightsLUTSymmetricInferableQuantizer(num_bits=num_bits,
-                                                          cluster_centers=cluster_centers,
+                                                          lut_values=lut_values,
                                                           threshold=threshold,
                                                           per_channel=per_channel,
                                                           channel_axis=channel_axis,
                                                           input_rank=input_rank,
-                                                          multiplier_n_bits=multiplier_n_bits,
+                                                          lut_values_bitwidth=lut_values_bitwidth,
                                                           eps=eps)
         layer_with_quantizer = KerasQuantizationWrapper(Conv2D(3,3),
                                                         {'kernel': quantizer})
@@ -169,21 +169,21 @@ class TestKerasLoadModel(unittest.TestCase):
 
 
     def test_save_and_load_weights_lut_pot(self):
-        cluster_centers = [-25, 25]
+        lut_values = [-25, 25]
         per_channel = True
         input_rank = 4
         num_bits = 8
         threshold = [1., 8., 4.]
         channel_axis = 3
-        multiplier_n_bits = 8
+        lut_values_bitwidth = 8
         eps = 1e-8
         quantizer = WeightsLUTPOTInferableQuantizer(num_bits=num_bits,
-                                                    cluster_centers=cluster_centers,
+                                                    lut_values=lut_values,
                                                     threshold=threshold,
                                                     per_channel=per_channel,
                                                     channel_axis=channel_axis,
                                                     input_rank=input_rank,
-                                                    multiplier_n_bits=multiplier_n_bits,
+                                                    lut_values_bitwidth=lut_values_bitwidth,
                                                     eps=eps)
         layer_with_quantizer = KerasQuantizationWrapper(Conv2D(3, 3),
                                                         {'kernel': quantizer})

--- a/tests/pytorch_tests/quantizers_tests/test_illegal_activation_lut_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_illegal_activation_lut_inferable_quantizer.py
@@ -26,7 +26,7 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
     def test_illegal_pot_lut_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               cluster_centers=np.asarray([25., 85.]),
+                                               lut_values=np.asarray([25., 85.]),
                                                # Not POT threshold
                                                threshold=np.asarray([3]),
                                                signed=True)
@@ -34,7 +34,7 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
 
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               cluster_centers=np.asarray([25., 85.]),
+                                               lut_values=np.asarray([25., 85.]),
                                                # Not float
                                                threshold=4,
                                                signed=True)
@@ -42,68 +42,68 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
         self.assertEqual('Threshold is expected to be numpy array, but is of type <class \'int\'>',
                                    str(e.exception))
 
-    def test_illegal_signed_cluster_centers_quantizer(self):
+    def test_illegal_signed_lut_values_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               cluster_centers=np.asarray([-25., 85.]),
+                                               lut_values=np.asarray([-25., 85.]),
                                                threshold=np.asarray([2.]),
                                                signed=False)
-        self.assertEqual('Expected unsigned cluster centers in unsigned activation quantization',
+        self.assertEqual('Expected unsigned lut values in unsigned activation quantization',
                                    str(e.exception))
 
-    def test_illegal_num_of_cluster_centers_quantizer(self):
-        cluster_centers = np.asarray([-25, 25, 3, 19, 55])
+    def test_illegal_num_of_lut_values_quantizer(self):
+        lut_values = np.asarray([-25, 25, 3, 19, 55])
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=2,
-                                               cluster_centers=cluster_centers,
+                                               lut_values=lut_values,
                                                threshold=np.asarray([2.]),
                                                signed=False)
-        self.assertEqual(f'Expected num of cluster centers to be less or equal than {2 ** 2} but got '
-                                   f'{len(cluster_centers)}', str(e.exception))
+        self.assertEqual(f'Expected num of lut values to be less or equal than {2 ** 2} but got '
+                                   f'{len(lut_values)}', str(e.exception))
 
-    def test_illegal_cluster_centers_quantizer(self):
+    def test_illegal_lut_values_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               cluster_centers=np.asarray([-25.6, 25]),
+                                               lut_values=np.asarray([-25.6, 25]),
                                                threshold=np.asarray([2.]),
                                                signed=False)
-        self.assertEqual('Expected cluster centers to be integers', str(e.exception))
+        self.assertEqual('Expected lut values to be integers', str(e.exception))
 
-    def test_illegal_cluster_centers_signed_range_quantizer(self):
+    def test_illegal_lut_values_signed_range_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=3,
-                                               cluster_centers=np.asarray([-25, 25]),
+                                               lut_values=np.asarray([-25, 25]),
                                                threshold=np.asarray([2.]),
                                                signed=True,
-                                               multiplier_n_bits=5)
-        self.assertEqual('Expected cluster centers in the quantization range', str(e.exception))
+                                               lut_values_bitwidth=5)
+        self.assertEqual('Expected lut values in the quantization range', str(e.exception))
 
-    def test_illegal_cluster_centers_unsigned_range_quantizer(self):
+    def test_illegal_lut_values_unsigned_range_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=3,
-                                               cluster_centers=np.asarray([15, 25]),
+                                               lut_values=np.asarray([15, 25]),
                                                threshold=np.asarray([2.]),
                                                signed=False,
-                                               multiplier_n_bits=4)
-        self.assertEqual('Expected cluster centers in the quantization range', str(e.exception))
+                                               lut_values_bitwidth=4)
+        self.assertEqual('Expected lut values in the quantization range', str(e.exception))
 
-    def test_illegal_num_bit_bigger_than_multiplier_n_bits_quantizer(self):
+    def test_illegal_num_bit_bigger_than_lut_values_bitwidth_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=10,
-                                               cluster_centers=np.asarray([-25, 25]),
+                                               lut_values=np.asarray([-25, 25]),
                                                threshold=np.asarray([2.]),
                                                signed=True,
-                                               multiplier_n_bits=8)
+                                               lut_values_bitwidth=8)
         self.assertEqual('Look-Up-Table bit configuration has 10 bits. It must be less then 8',
                                    str(e.exception))
 
-    def test_warning_num_bit_equal_multiplier_n_bits_quantizer(self):
+    def test_warning_num_bit_equal_lut_values_bitwidth_quantizer(self):
         with warnings.catch_warnings(record=True) as w:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               cluster_centers=np.asarray([-25, 25]),
+                                               lut_values=np.asarray([-25, 25]),
                                                threshold=np.asarray([2.]),
                                                signed=True,
-                                               multiplier_n_bits=8)
+                                               lut_values_bitwidth=8)
         self.assertTrue(
             'Num of bits equal to multiplier n bits, Please be aware LUT quantizier may be inefficient '
             'in that case, consider using SymmetricInferableQuantizer instead'
@@ -112,10 +112,10 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
     def test_illegal_threshold_type_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=3,
-                                               cluster_centers=np.asarray([-25, 25]),
+                                               lut_values=np.asarray([-25, 25]),
                                                threshold=[2.],
                                                signed=True,
-                                               multiplier_n_bits=8)
+                                               lut_values_bitwidth=8)
         self.assertEqual('Threshold is expected to be numpy array, but is of type <class \'list\'>',
                                    str(e.exception))
 
@@ -123,10 +123,10 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
         threshold = np.array([[4., 2.], [2., 16.]])
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=3,
-                                               cluster_centers=np.asarray([-25, 25]),
+                                               lut_values=np.asarray([-25, 25]),
                                                threshold=threshold,
                                                signed=True,
-                                               multiplier_n_bits=8)
+                                               lut_values_bitwidth=8)
         self.assertEqual(f'Threshold is expected to be flatten, but of shape {threshold.shape}',
                                    str(e.exception))
 
@@ -134,10 +134,10 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
         threshold = np.asarray([1., 4.])
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=3,
-                                               cluster_centers=np.asarray([-25, 25]),
+                                               lut_values=np.asarray([-25, 25]),
                                                threshold=threshold,
                                                signed=True,
-                                               multiplier_n_bits=8)
+                                               lut_values_bitwidth=8)
         self.assertEqual(
             'For activation, quantization per channel is not supported and threshold should be of length '
             '1 but is 2', str(e.exception))

--- a/tests/pytorch_tests/quantizers_tests/test_illegal_weights_lut_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_illegal_weights_lut_inferable_quantizer.py
@@ -25,110 +25,110 @@ from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_
 
 class BasePytorchWeightsIllegalLutQuantizerTest(unittest.TestCase):
 
-    def illegal_cluster_centers_inferable_quantizer_test(self, inferable_quantizer, threshold, cluster_centers,
+    def illegal_lut_values_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
                                                          per_channel, channel_axis):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis)
-        self.assertEqual('Expected cluster centers to be integers', str(e.exception))
+        self.assertEqual('Expected lut values to be integers', str(e.exception))
 
-    def illegal_num_of_cluster_centers_inferable_quantizer_test(self, inferable_quantizer, threshold, cluster_centers,
+    def illegal_num_of_lut_values_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
                                                                 per_channel, channel_axis):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=2,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis)
-        self.assertEqual(f'Expected num of cluster centers to be less or equal than {2 ** 2} but got '
-                         f'{len(cluster_centers)}', str(e.exception))
+        self.assertEqual(f'Expected num of lut values to be less or equal than {2 ** 2} but got '
+                         f'{len(lut_values)}', str(e.exception))
 
-    def illegal_cluster_centers_range_inferable_quantizer_test(self, inferable_quantizer, threshold, cluster_centers,
+    def illegal_lut_values_range_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
                                                                per_channel, channel_axis,
-                                                               multiplier_n_bits):
+                                                               lut_values_bitwidth):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis,
-                                multiplier_n_bits=multiplier_n_bits)
-        self.assertEqual('Expected cluster centers in the quantization range', str(e.exception))
+                                lut_values_bitwidth=lut_values_bitwidth)
+        self.assertEqual('Expected lut values in the quantization range', str(e.exception))
 
-    def illegal_num_bit_bigger_than_multiplier_n_bits_inferable_quantizer_test(self, inferable_quantizer, threshold,
-                                                                               cluster_centers,
+    def illegal_num_bit_bigger_than_lut_values_bitwidth_inferable_quantizer_test(self, inferable_quantizer, threshold,
+                                                                               lut_values,
                                                                                num_bits,
                                                                                per_channel, channel_axis,
-                                                                               multiplier_n_bits):
+                                                                               lut_values_bitwidth):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=num_bits,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis,
-                                multiplier_n_bits=multiplier_n_bits)
+                                lut_values_bitwidth=lut_values_bitwidth)
         self.assertEqual('Look-Up-Table bit configuration has 10 bits. It must be less then 8'
                          , str(e.exception))
 
-    def warning_num_bit_equal_multiplier_n_bits_inferable_quantizer_test(self, inferable_quantizer, threshold,
-                                                                         cluster_centers,
+    def warning_num_bit_equal_lut_values_bitwidth_inferable_quantizer_test(self, inferable_quantizer, threshold,
+                                                                         lut_values,
                                                                          num_bits,
                                                                          per_channel, channel_axis,
-                                                                         multiplier_n_bits):
+                                                                         lut_values_bitwidth):
         with warnings.catch_warnings(record=True) as w:
             inferable_quantizer(num_bits=num_bits,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis,
-                                multiplier_n_bits=multiplier_n_bits)
+                                lut_values_bitwidth=lut_values_bitwidth)
         self.assertTrue(
             'Num of bits equal to multiplier n bits, Please be aware LUT quantizier may be inefficient '
             'in that case, consider using SymmetricInferableQuantizer instead'
             in [str(warning.message) for warning in w])
 
-    def illegal_num_of_thresholds_inferable_quantizer_test(self, inferable_quantizer, threshold, cluster_centers,
+    def illegal_num_of_thresholds_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
                                                            per_channel, channel_axis):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis)
         self.assertEqual('In per-tensor quantization threshold should be of length 1 but is 2',
                          str(e.exception))
 
-    def illegal_threshold_type_inferable_quantizer_test(self, inferable_quantizer, threshold, cluster_centers,
+    def illegal_threshold_type_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
                                                         per_channel, channel_axis):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis)
         self.assertEqual('Threshold is expected to be numpy array, but is of type <class \'list\'>',
                          str(e.exception))
 
-    def illegal_threshold_shape_inferable_quantizer_test(self, inferable_quantizer, threshold, cluster_centers,
+    def illegal_threshold_shape_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
                                                          per_channel, channel_axis):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis)
         self.assertEqual(f'Threshold is expected to be flatten, but of shape {threshold.shape}',
                          str(e.exception))
 
-    def missing_channel_axis_inferable_quantizer(self, inferable_quantizer, threshold, cluster_centers,
+    def missing_channel_axis_inferable_quantizer(self, inferable_quantizer, threshold, lut_values,
                                                  per_channel):
         with self.assertRaises(Exception) as e:
             inferable_quantizer(num_bits=8,
                                 per_channel=per_channel,
-                                cluster_centers=cluster_centers,
+                                lut_values=lut_values,
                                 threshold=threshold)
         self.assertEqual('Channel axis is missing in per channel quantization', str(e.exception))
 
@@ -140,73 +140,73 @@ class TestPytorchWeightsIllegalSymmetricLutQuantizer(BasePytorchWeightsIllegalLu
 
         self.inferable_quantizer = WeightsLUTSymmetricInferableQuantizer
 
-    def test_illegal_cluster_centers_symmetric_lut_quantizer(self):
-        self.illegal_cluster_centers_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_lut_values_symmetric_lut_quantizer(self):
+        self.illegal_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                               threshold=np.asarray([2.]),
-                                                              cluster_centers=np.asarray([-25.6, 25]),
+                                                              lut_values=np.asarray([-25.6, 25]),
                                                               per_channel=False,
                                                               channel_axis=None)
 
-    def test_illegal_num_of_cluster_centers_symmetric_lut_quantizer(self):
-        self.illegal_num_of_cluster_centers_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_num_of_lut_values_symmetric_lut_quantizer(self):
+        self.illegal_num_of_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                      threshold=np.asarray([2.]),
-                                                                     cluster_centers=np.asarray([-25, 25, 3, 19, 55]),
+                                                                     lut_values=np.asarray([-25, 25, 3, 19, 55]),
                                                                      per_channel=False,
                                                                      channel_axis=None)
 
-    def test_illegal_cluster_centers_range_symmetric_lut_quantizer(self):
-        self.illegal_cluster_centers_range_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_lut_values_range_symmetric_lut_quantizer(self):
+        self.illegal_lut_values_range_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                     threshold=np.asarray([2.]),
-                                                                    cluster_centers=np.asarray([-25, 25]),
+                                                                    lut_values=np.asarray([-25, 25]),
                                                                     per_channel=False,
                                                                     channel_axis=None,
-                                                                    multiplier_n_bits=5)
+                                                                    lut_values_bitwidth=5)
 
-    def test_illegal_num_bit_bigger_than_multiplier_n_bits_symmetric_lut_quantizer(self):
-        self.illegal_num_bit_bigger_than_multiplier_n_bits_inferable_quantizer_test(
+    def test_illegal_num_bit_bigger_than_lut_values_bitwidth_symmetric_lut_quantizer(self):
+        self.illegal_num_bit_bigger_than_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
             threshold=np.asarray([2.]),
-            cluster_centers=np.asarray([-25, 25]),
+            lut_values=np.asarray([-25, 25]),
             per_channel=False,
             channel_axis=None,
-            multiplier_n_bits=8,
+            lut_values_bitwidth=8,
             num_bits=10)
 
-    def test_warning_num_bit_equal_multiplier_n_bits_symmetric_lut_quantizer(self):
-        self.warning_num_bit_equal_multiplier_n_bits_inferable_quantizer_test(
+    def test_warning_num_bit_equal_lut_values_bitwidth_symmetric_lut_quantizer(self):
+        self.warning_num_bit_equal_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
             threshold=np.asarray([2.]),
-            cluster_centers=np.asarray([-25, 25]),
+            lut_values=np.asarray([-25, 25]),
             per_channel=False,
             channel_axis=None,
-            multiplier_n_bits=8,
+            lut_values_bitwidth=8,
             num_bits=8)
 
     def test_illegal_threshold_type_symmetric_lut_quantizer(self):
         self.illegal_threshold_type_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                              threshold=[3., 2.],
-                                                             cluster_centers=np.asarray([-25, 25]),
+                                                             lut_values=np.asarray([-25, 25]),
                                                              per_channel=False,
                                                              channel_axis=None)
 
     def test_illegal_threshold_shape_symmetric_lut_quantizer(self):
         self.illegal_threshold_shape_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                               threshold=np.array([[3., 2.], [2., 5.]]),
-                                                              cluster_centers=np.asarray([-25, 25]),
+                                                              lut_values=np.asarray([-25, 25]),
                                                               per_channel=False,
                                                               channel_axis=None)
 
     def test_illegal_num_of_thresholds_symmetric_lut_quantizer(self):
         self.illegal_num_of_thresholds_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                 threshold=np.asarray([2., 7.]),
-                                                                cluster_centers=np.asarray([-25, 25]),
+                                                                lut_values=np.asarray([-25, 25]),
                                                                 per_channel=False,
                                                                 channel_axis=None)
 
     def test_missing_channel_axis_symmetric_lut_quantizer(self):
         self.missing_channel_axis_inferable_quantizer(inferable_quantizer=self.inferable_quantizer,
                                                       threshold=np.asarray([2.]),
-                                                      cluster_centers=np.asarray([-25, 25]),
+                                                      lut_values=np.asarray([-25, 25]),
                                                       per_channel=True)
 
 
@@ -220,7 +220,7 @@ class TestPytorchWeightsIllegalPotLutQuantizer(BasePytorchWeightsIllegalLutQuant
     def test_threshold_not_pot_lut_quantizer(self):
         with self.assertRaises(Exception) as e:
             self.inferable_quantizer(num_bits=8,
-                                     cluster_centers=np.asarray([25., 85.]),
+                                     lut_values=np.asarray([25., 85.]),
                                      per_channel=False,
                                      # Not POT threshold
                                      threshold=np.asarray([3]))
@@ -228,78 +228,78 @@ class TestPytorchWeightsIllegalPotLutQuantizer(BasePytorchWeightsIllegalLutQuant
 
         with self.assertRaises(Exception) as e:
             self.inferable_quantizer(num_bits=8,
-                                     cluster_centers=np.asarray([25., 85.]),
+                                     lut_values=np.asarray([25., 85.]),
                                      per_channel=False,
                                      # More than one threshold in per-tensor quantization
                                      threshold=np.asarray([2, 3]))
         self.assertEqual('In per-tensor quantization threshold should be of length 1 but is 2',
                          str(e.exception))
 
-    def test_illegal_cluster_centers_pot_lut_quantizer(self):
-        self.illegal_cluster_centers_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_lut_values_pot_lut_quantizer(self):
+        self.illegal_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                               threshold=np.asarray([2.]),
-                                                              cluster_centers=np.asarray([-25.6, 25]),
+                                                              lut_values=np.asarray([-25.6, 25]),
                                                               per_channel=False,
                                                               channel_axis=None)
 
-    def test_illegal_num_of_cluster_centers_pot_lut_quantizer(self):
-        self.illegal_num_of_cluster_centers_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_num_of_lut_values_pot_lut_quantizer(self):
+        self.illegal_num_of_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                      threshold=np.asarray([2.]),
-                                                                     cluster_centers=np.asarray([-25, 25, 3, 19, 55]),
+                                                                     lut_values=np.asarray([-25, 25, 3, 19, 55]),
                                                                      per_channel=False,
                                                                      channel_axis=None)
 
-    def test_illegal_cluster_centers_range_pot_lut_quantizer(self):
-        self.illegal_cluster_centers_range_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
+    def test_illegal_lut_values_range_pot_lut_quantizer(self):
+        self.illegal_lut_values_range_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                     threshold=np.asarray([2.]),
-                                                                    cluster_centers=np.asarray([-25, 25]),
+                                                                    lut_values=np.asarray([-25, 25]),
                                                                     per_channel=False,
                                                                     channel_axis=None,
-                                                                    multiplier_n_bits=5)
+                                                                    lut_values_bitwidth=5)
 
-    def test_illegal_num_bit_bigger_than_multiplier_n_bits_pot_lut_quantizer(self):
-        self.illegal_num_bit_bigger_than_multiplier_n_bits_inferable_quantizer_test(
+    def test_illegal_num_bit_bigger_than_lut_values_bitwidth_pot_lut_quantizer(self):
+        self.illegal_num_bit_bigger_than_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
             threshold=np.asarray([2.]),
-            cluster_centers=np.asarray([-25, 25]),
+            lut_values=np.asarray([-25, 25]),
             per_channel=False,
             channel_axis=None,
-            multiplier_n_bits=8,
+            lut_values_bitwidth=8,
             num_bits=10)
 
-    def test_warning_num_bit_equal_multiplier_n_bits_pot_lut_quantizer(self):
-        self.warning_num_bit_equal_multiplier_n_bits_inferable_quantizer_test(
+    def test_warning_num_bit_equal_lut_values_bitwidth_pot_lut_quantizer(self):
+        self.warning_num_bit_equal_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
             threshold=np.asarray([2.]),
-            cluster_centers=np.asarray([-25, 25]),
+            lut_values=np.asarray([-25, 25]),
             per_channel=False,
             channel_axis=None,
-            multiplier_n_bits=8,
+            lut_values_bitwidth=8,
             num_bits=8)
 
     def tets_illegal_threshold_type_pot_lut_quantizer(self):
         self.illegal_threshold_type_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                              threshold=[4., 2.],
-                                                             cluster_centers=np.asarray([-25, 25]),
+                                                             lut_values=np.asarray([-25, 25]),
                                                              per_channel=False,
                                                              channel_axis=None)
 
     def test_illegal_threshold_shape_pot_lut_quantizer(self):
         self.illegal_threshold_shape_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                               threshold=np.array([[4., 2.], [2., 8.]]),
-                                                              cluster_centers=np.asarray([-25, 25]),
+                                                              lut_values=np.asarray([-25, 25]),
                                                               per_channel=False,
                                                               channel_axis=None)
 
     def test_illegal_num_of_thresholds_pot_lut_quantizer(self):
         self.illegal_num_of_thresholds_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                                 threshold=np.asarray([2., 8.]),
-                                                                cluster_centers=np.asarray([-25, 25]),
+                                                                lut_values=np.asarray([-25, 25]),
                                                                 per_channel=False,
                                                                 channel_axis=None)
 
     def test_missing_channel_axis_pot_lut_quantizer(self):
         self.missing_channel_axis_inferable_quantizer(inferable_quantizer=self.inferable_quantizer,
                                                       threshold=np.asarray([2.]),
-                                                      cluster_centers=np.asarray([-25, 25]),
+                                                      lut_values=np.asarray([-25, 25]),
                                                       per_channel=True)

--- a/tests/pytorch_tests/test_pytorch_load_model.py
+++ b/tests/pytorch_tests/test_pytorch_load_model.py
@@ -93,19 +93,19 @@ class TestPytorchLoadModel(unittest.TestCase):
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_activation_lut_pot(self):
-        cluster_centers = np.asarray([-25, 25])
+        lut_values = np.asarray([-25, 25])
         thresholds = np.asarray([4.])
         num_bits = 3
         signed = True
-        multiplier_n_bits = 8
+        lut_values_bitwidth = 8
         eps = 1e-8
 
         quantizer = ActivationLutPOTInferableQuantizer(num_bits=num_bits,
-                                                       cluster_centers=cluster_centers,
+                                                       lut_values=lut_values,
                                                        signed=signed,
                                                        threshold=thresholds,
-                                                       multiplier_n_bits=
-                                                       multiplier_n_bits,
+                                                       lut_values_bitwidth=
+                                                       lut_values_bitwidth,
                                                        eps=eps)
 
         layer_with_quantizer = PytorchActivationQuantizationHolder(quantizer)
@@ -147,38 +147,38 @@ class TestPytorchLoadModel(unittest.TestCase):
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_weights_lut_symmetric(self):
-        cluster_centers = np.asarray([-25, 25])
+        lut_values = np.asarray([-25, 25])
         per_channel = True
         num_bits = 8
         threshold = np.asarray([3., 8., 7.])
         channel_axis = 3
-        multiplier_n_bits = 8
+        lut_values_bitwidth = 8
         eps = 1e-8
         quantizer = WeightsLUTSymmetricInferableQuantizer(num_bits=num_bits,
-                                                          cluster_centers=cluster_centers,
+                                                          lut_values=lut_values,
                                                           threshold=threshold,
                                                           per_channel=per_channel,
                                                           channel_axis=channel_axis,
-                                                          multiplier_n_bits=multiplier_n_bits,
+                                                          lut_values_bitwidth=lut_values_bitwidth,
                                                           eps=eps)
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 10, 3),
                                                           {'weight': quantizer}).to(self.device)
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_weights_lut_pot(self):
-        cluster_centers = np.asarray([-25, 25])
+        lut_values = np.asarray([-25, 25])
         per_channel = True
         num_bits = 8
         threshold = np.asarray([1., 8., 4.])
         channel_axis = 3
-        multiplier_n_bits = 8
+        lut_values_bitwidth = 8
         eps = 1e-8
         quantizer = WeightsLUTPOTInferableQuantizer(num_bits=num_bits,
-                                                    cluster_centers=cluster_centers,
+                                                    lut_values=lut_values,
                                                     threshold=threshold,
                                                     per_channel=per_channel,
                                                     channel_axis=channel_axis,
-                                                    multiplier_n_bits=multiplier_n_bits,
+                                                    lut_values_bitwidth=lut_values_bitwidth,
                                                     eps=eps)
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 10, 3),
                                                           {'weight': quantizer}).to(self.device)


### PR DESCRIPTION
Changed LUT quantizers arguments names:
* multiplier_n_bits -> lut_values_bitwidth
* cluster_centers -> lut_values

And added a "signed" property (with True value by definition) to Keras symmetric weights quantizers.