### PR TITLE
Pytorch fixes

### DIFF
--- a/mct_quantizers/pytorch/onnxruntime_validations.py
+++ b/mct_quantizers/pytorch/onnxruntime_validations.py
@@ -1,5 +1,19 @@
-import numpy as np
+# Copyright 2023 Sony Semiconductor Israel, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
+import numpy as np
 
 
 def validate_weight_params(input_tensor: np.ndarray,
@@ -8,6 +22,10 @@ def validate_weight_params(input_tensor: np.ndarray,
                            per_channel: int,
                            channel_axis: int
                            ):
+    """
+    Validate onnxruntime weight quantization function params.
+    """
+
     assert isinstance(input_tensor,
                       np.ndarray), f"Input tensor expected to be a numpy array but is {type(input_tensor)}"
 
@@ -19,22 +37,29 @@ def validate_weight_params(input_tensor: np.ndarray,
     assert min_range.ndim == 1, f"min_range ndim expected to be 1 but is {min_range.ndim}"
     assert max_range.ndim == 1, f"max_range ndim expected to be 1 but is {max_range.ndim}"
 
-    assert min_range.shape[0]==max_range.shape[0], f'Expected min and max ranges to have same shapes but min_range shape: {min_range.shape} and max_range shape: {max_range.shape}'
+    assert min_range.shape[0] == max_range.shape[
+        0], f'Expected min and max ranges to have same shapes but min_range shape: {min_range.shape} and max_range ' \
+            f'shape: {max_range.shape}'
 
-    assert np.all(min_range < max_range), f"max_range should be greater than min_range but max: {max_range}, min: {min_range}"
+    assert np.all(
+        min_range < max_range), f"max_range should be greater than min_range but max: {max_range}, min: {min_range}"
 
     if per_channel:
         assert channel_axis is not None, f'In per channel quantization channel_axis must be provided'
         assert input_tensor.shape[channel_axis] == min_range.shape[
-            0], f"Mismatch between channels to quantize {input_tensor.shape[channel_axis]} to number of quantization ranges: " \
+            0], f"Mismatch between channels to quantize {input_tensor.shape[channel_axis]} to number of quantization " \
+                f"ranges: " \
                 f"{min_range.shape[0]}"
     else:
         assert min_range.shape[0] == 1, f'In per tensor quantization only one quantization range should be provided'
 
 
 def validate_activation_params(input_tensor: np.ndarray,
-                           min_range: float,
-                           max_range: float):
+                               min_range: float,
+                               max_range: float):
+    """
+    Validate onnxruntime activation quantization function params.
+    """
 
     assert isinstance(input_tensor,
                       np.ndarray), f"Input tensor expected to be a numpy array but is {type(input_tensor)}"
@@ -43,4 +68,4 @@ def validate_activation_params(input_tensor: np.ndarray,
                       float), f"min_range expected to be float but is {type(min_range)}"
     assert isinstance(max_range,
                       float), f"max_range expected to be float but is {type(max_range)}"
-    assert min_range<max_range, f"max_range should be greate than min_range but max: {max_range}, min: {min_range}"
+    assert min_range < max_range, f"max_range should be greate than min_range but max: {max_range}, min: {min_range}"

--- a/mct_quantizers/pytorch/onnxruntime_validations.py
+++ b/mct_quantizers/pytorch/onnxruntime_validations.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+
+
+def validate_weight_params(input_tensor: np.ndarray,
+                           min_range: np.ndarray,
+                           max_range: np.ndarray,
+                           per_channel: int,
+                           channel_axis: int
+                           ):
+    assert isinstance(input_tensor,
+                      np.ndarray), f"Input tensor expected to be a numpy array but is {type(input_tensor)}"
+
+    assert isinstance(min_range,
+                      np.ndarray), f"min_range expected to be a numpy array but is {type(min_range)}"
+    assert isinstance(max_range,
+                      np.ndarray), f"max_range expected to be a numpy array but is {type(max_range)}"
+
+    assert min_range.ndim == 1, f"min_range ndim expected to be 1 but is {min_range.ndim}"
+    assert max_range.ndim == 1, f"max_range ndim expected to be 1 but is {max_range.ndim}"
+
+    assert min_range.shape[0]==max_range.shape[0], f'Expected min and max ranges to have same shapes but min_range shape: {min_range.shape} and max_range shape: {max_range.shape}'
+
+    assert np.all(min_range < max_range), f"max_range should be greater than min_range but max: {max_range}, min: {min_range}"
+
+    if per_channel:
+        assert channel_axis is not None, f'In per channel quantization channel_axis must be provided'
+        assert input_tensor.shape[channel_axis] == min_range.shape[
+            0], f"Mismatch between channels to quantize {input_tensor.shape[channel_axis]} to number of quantization ranges: " \
+                f"{min_range.shape[0]}"
+    else:
+        assert min_range.shape[0] == 1, f'In per tensor quantization only one quantization range should be provided'
+
+
+def validate_activation_params(input_tensor: np.ndarray,
+                           min_range: float,
+                           max_range: float):
+
+    assert isinstance(input_tensor,
+                      np.ndarray), f"Input tensor expected to be a numpy array but is {type(input_tensor)}"
+
+    assert isinstance(min_range,
+                      float), f"min_range expected to be float but is {type(min_range)}"
+    assert isinstance(max_range,
+                      float), f"max_range expected to be float but is {type(max_range)}"
+    assert min_range<max_range, f"max_range should be greate than min_range but max: {max_range}, min: {min_range}"

--- a/mct_quantizers/pytorch/quantizer_utils.py
+++ b/mct_quantizers/pytorch/quantizer_utils.py
@@ -17,6 +17,8 @@ from typing import Tuple
 import torch
 import numpy as np
 
+from mct_quantizers.logger import Logger
+
 
 def get_working_device():
     """
@@ -81,6 +83,12 @@ def fix_range_to_include_zero(range_min: torch.Tensor,
 
     min_range_adj = min_range_adj * mid_range + max_negative * range_min
     max_range_adj = max_range_adj * mid_range + min_positive * range_max
+
+    grid_range = (range_max - range_min)
+    if not torch.all(torch.isclose((min_range_adj - range_min)/grid_range, torch.tensor(0.), atol=1e-6)) or not torch.all(torch.isclose((min_range_adj - range_min)/grid_range, torch.tensor(0.), atol=1e-6)):
+        Logger.warning(
+                f"Adjusting (min_range, max_range) from ({range_min},{range_max}) to ({min_range_adj},{max_range_adj})")  # pragma: no cover
+
     return min_range_adj, max_range_adj
 
 

--- a/mct_quantizers/pytorch/quantizer_utils.py
+++ b/mct_quantizers/pytorch/quantizer_utils.py
@@ -116,7 +116,10 @@ def lut_quantizer(tensor_data: torch.Tensor,
     Returns: Quantized tensor.
     """
 
-    tensor = int_quantization_with_threshold(tensor_data, n_bits=lut_values_bitwidth, signed=signed, threshold=threshold,
+    tensor = int_quantization_with_threshold(tensor_data,
+                                             n_bits=lut_values_bitwidth,
+                                             signed=signed,
+                                             threshold=threshold,
                                              eps=eps)
     tensor = tensor.unsqueeze(-1)
 

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -19,6 +19,7 @@ import numpy as np
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTENSIONS, ONNX_CUSTOM_OP_DOMAIN
 from mct_quantizers.common.quant_info import QuantizationMethod
+from mct_quantizers.pytorch.onnxruntime_validations import validate_activation_params
 
 if FOUND_TORCH:
     import torch
@@ -209,6 +210,10 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
            Returns:
                np.ndarray: Symmetrically quantized tensor.
         """
+
+        validate_activation_params(input_tensor=input_tensor,
+                               min_range=-threshold if signed else 0.,
+                               max_range=threshold)
 
         if signed:
             scale = threshold / (2 ** (num_bits - 1))

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_symmetric_inferable_quantizer.py
@@ -78,6 +78,8 @@ if FOUND_TORCH:
                 threshold=threshold,
                 signed=signed)
 
+            assert len(threshold)==1, f'For activation, only per-tensor quantization is supported. Thus, threshold should be of length 1 but is {len(threshold)}'
+
             assert self.threshold_np.shape[0] == 1
             self.threshold_np = self.threshold_np[0]
 

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -20,6 +20,7 @@ from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, Quant
 from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTENSIONS, ONNX_CUSTOM_OP_DOMAIN
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.common.quant_utils import adjust_range_to_include_zero
+from mct_quantizers.pytorch.onnxruntime_validations import validate_activation_params
 
 if FOUND_TORCH:
     import torch
@@ -202,6 +203,10 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
         Returns:
             Quantized data.
         """
+
+        validate_activation_params(input_tensor=tensor_data,
+                               min_range=range_min,
+                               max_range=range_max)
 
         # adjusts the quantization rage so the quantization grid include zero.
         a, b = adjust_range_to_include_zero(range_min, range_max, n_bits)

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -93,10 +93,10 @@ if FOUND_TORCH:
             assert isinstance(max_range, list), f'max_range is expected to be a list, but is of type {type(max_range)}'
 
             assert len(
-                min_range) == 1, f'For activation, quantization per channel is not supported and min_range should be ' \
+                min_range) == 1, f'For activation, only per-tensor quantization is supported. Thus, min_range should be ' \
                                  f'of length 1 but is {len(min_range)}'
             assert len(
-                max_range) == 1, f'For activation, quantization per channel is not supported and max_range should be ' \
+                max_range) == 1, f'For activation, only per-tensor quantization is supported. Thus, max_range should be ' \
                                  f'of length 1 but is {len(max_range)}'
 
             # Activation is per-tensor thus we expect only a single min/max values

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_uniform_inferable_quantizer.py
@@ -100,18 +100,11 @@ if FOUND_TORCH:
                                  f'of length 1 but is {len(max_range)}'
 
             # Activation is per-tensor thus we expect only a single min/max values
-            min_range = min_range[0]
-            max_range = max_range[0]
+            self.min_range = self.min_range[0].cpu().item()
+            self.max_range = self.max_range[0].cpu().item()
 
-            # fixing quantization range to include 0
-            a = 0 if min_range > 0 else min_range
-            b = 0 if max_range < 0 else max_range
-
-            self.min_range = a
-            self.max_range = b
-
-            self.scale = float((b - a) / ((2 ** num_bits) - 1))
-            self.zero_point = int(-np.round(a / self.scale))  # zp has to be positive, and a <=0, so we multiply by -1
+            self.scale = float((self.max_range-self.min_range) / ((2 ** num_bits) - 1))
+            self.zero_point = int(-np.round(self.min_range / self.scale))  # zp has to be positive, and a <=0, so we multiply by -1
 
         def __call__(self, inputs: torch.Tensor):
             """

--- a/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
@@ -48,6 +48,9 @@ if FOUND_TORCH:
             assert isinstance(min_range, list), f'min_range is expected to be a list, but is of type {type(min_range)}'
             assert isinstance(max_range, list), f'max_range is expected to be a list, but is of type {type(max_range)}'
 
+            for _min, _max in zip(min_range, max_range):
+                assert _min<_max, f"Max range must be greater than min value but min is {_min} and max is {_max}"
+
             # Align mix/max numpy arrays so they are torch Tensors on the working device
             min_range = to_torch_tensor(np.asarray(min_range)).to(get_working_device())
             max_range = to_torch_tensor(np.asarray(max_range)).to(get_working_device())

--- a/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import List
+
 import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizerID
@@ -29,8 +31,8 @@ if FOUND_TORCH:
 
         def __init__(self,
                      num_bits: int,
-                     min_range: np.ndarray,
-                     max_range: np.ndarray):
+                     min_range: List[float],
+                     max_range: List[float]):
             """
             Initialize the quantizer with the specified parameters.
 
@@ -41,6 +43,9 @@ if FOUND_TORCH:
             """
 
             super(BaseUniformInferableQuantizer, self).__init__()
+            assert isinstance(min_range, list), f'min_range is expected to be a list, but is of type {type(min_range)}'
+            assert isinstance(max_range, list), f'max_range is expected to be a list, but is of type {type(max_range)}'
+
             self.num_bits = num_bits
             self.min_range = min_range
             self.max_range = max_range

--- a/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/base_uniform_inferable_quantizer.py
@@ -19,6 +19,7 @@ import numpy as np
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH
 from mct_quantizers.common.quant_info import QuantizationMethod
+from mct_quantizers.pytorch.quantizer_utils import get_working_device, to_torch_tensor, fix_range_to_include_zero
 
 if FOUND_TORCH:
     from mct_quantizers.pytorch.quantizers.base_pytorch_inferable_quantizer import BasePyTorchInferableQuantizer
@@ -43,12 +44,21 @@ if FOUND_TORCH:
             """
 
             super(BaseUniformInferableQuantizer, self).__init__()
+
             assert isinstance(min_range, list), f'min_range is expected to be a list, but is of type {type(min_range)}'
             assert isinstance(max_range, list), f'max_range is expected to be a list, but is of type {type(max_range)}'
 
-            self.num_bits = num_bits
+            # Align mix/max numpy arrays so they are torch Tensors on the working device
+            min_range = to_torch_tensor(np.asarray(min_range)).to(get_working_device())
+            max_range = to_torch_tensor(np.asarray(max_range)).to(get_working_device())
+
+            min_range, max_range = fix_range_to_include_zero(min_range,
+                                                             max_range,
+                                                             num_bits)
             self.min_range = min_range
             self.max_range = max_range
+
+            self.num_bits = num_bits
             self.min_quantized_domain = 0
             self.max_quantized_domain = 2 ** num_bits - 1
 

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -19,6 +19,7 @@ import numpy as np
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
 from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTENSIONS, ONNX_CUSTOM_OP_DOMAIN
 from mct_quantizers.common.quant_info import QuantizationMethod
+from mct_quantizers.pytorch.onnxruntime_validations import validate_weight_params
 
 if FOUND_TORCH:
     import torch
@@ -211,8 +212,8 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
     from onnxruntime_extensions import onnx_op, PyCustomOpDef
     def quantize_sym_weights_numpy(input_tensor: np.ndarray,
                                    num_bits: int,
-                                   threshold: float,
-                                   per_channel: bool,
+                                   threshold: np.ndarray,
+                                   per_channel: int,
                                    channel_axis: int):
         """
            Quantizes the input tensor symmetrically using numpy.
@@ -227,6 +228,12 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
            Returns:
                Symmetrically quantized tensor.
         """
+        validate_weight_params(input_tensor=input_tensor,
+                               per_channel=per_channel,
+                               min_range=-threshold,
+                               max_range=threshold,
+                               channel_axis=channel_axis)
+
         scale = threshold / (2 ** (num_bits - 1))
         _min, _max = -threshold, threshold - scale
         if per_channel:
@@ -255,7 +262,8 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
                  "channel_axis": PyCustomOpDef.dt_int64,
              })
     def weight_sym_ort(input_tensor: np.ndarray,
-                       threshold: np.ndarray, **kwargs):
+                       threshold: np.ndarray,
+                       **kwargs):
 
         return quantize_sym_weights_numpy(input_tensor,
                                           kwargs["num_bits"],

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -105,6 +105,13 @@ if FOUND_TORCH:
             super(WeightsUniformInferableQuantizer, self).__init__(num_bits=num_bits,
                                                                    min_range=min_range,
                                                                    max_range=max_range)
+            if per_channel:
+                assert channel_axis is not None, f'Channel axis is missing in per channel quantization'
+                assert len(min_range) >= 1, f'In per-channel quantization min_range should be of length >= 1 but is {len(min_range)}'
+                assert len(max_range) >= 1, f'In per-channel quantization max_range should be of length >= 1 but is {len(max_range)}'
+            else:
+                assert len(min_range) == 1, f'In per-tensor quantization min_range should be of length 1 but is {len(min_range)}'
+                assert len(max_range) == 1, f'In per-tensor quantization max_range should be of length 1 but is {len(max_range)}'
 
             # Align mix/max numpy arrays so they are torch Tensors on the working device
             min_range = to_torch_tensor(np.asarray(min_range)).to(get_working_device())

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -21,7 +21,7 @@ from mct_quantizers.common.constants import FOUND_TORCH, FOUND_ONNXRUNTIME_EXTEN
 from mct_quantizers.common.quant_info import QuantizationMethod
 from mct_quantizers.common.quant_utils import adjust_range_to_include_zero
 from mct_quantizers.logger import Logger
-
+from mct_quantizers.pytorch.onnxruntime_validations import validate_weight_params
 
 if FOUND_TORCH:
     import torch
@@ -255,6 +255,13 @@ if FOUND_ONNXRUNTIME_EXTENSIONS:
            Returns:
                Symmetrically quantized tensor.
         """
+
+        validate_weight_params(input_tensor=input_tensor,
+                               per_channel=per_channel,
+                               min_range=min_range,
+                               max_range=max_range,
+                               channel_axis=channel_axis)
+
         # adjusts the quantization rage so the quantization grid include zero.
         a, b = adjust_range_to_include_zero(min_range, max_range, num_bits)
 

--- a/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
@@ -186,5 +186,30 @@ class TestONNXExportActivationQuantizers(unittest.TestCase):
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
         assert node_qparams[MCTQ_VERSION] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams[MCTQ_VERSION]}'
 
+    def test_illegal_arguments(self):
 
+        # Test activation with more than one threshold
+        thresholds = [3., 3.]
+        with self.assertRaises(Exception) as e:
+            pytorch_quantizers.ActivationPOTInferableQuantizer(num_bits=8,
+                                                                  signed=True,
+                                                                  threshold=thresholds)
+        self.assertEqual(f"For activation, only per-tensor quantization is supported. Thus, threshold should be of length 1 but is {len(thresholds)}", str(e.exception))
+
+        with self.assertRaises(Exception) as e:
+            pytorch_quantizers.ActivationSymmetricInferableQuantizer(num_bits=8,
+                                                                  signed=True,
+                                                                  threshold=thresholds)
+        self.assertEqual(f"For activation, only per-tensor quantization is supported. Thus, threshold should be of length 1 but is {len(thresholds)}", str(e.exception))
+        with self.assertRaises(Exception) as e:
+            pytorch_quantizers.ActivationUniformInferableQuantizer(num_bits=8,
+                                                                  min_range=[-t for t in thresholds],
+                                                                   max_range=[3.])
+        self.assertEqual(f"For activation, only per-tensor quantization is supported. Thus, min_range should be of length 1 but is {len(thresholds)}", str(e.exception))
+
+        with self.assertRaises(Exception) as e:
+            pytorch_quantizers.ActivationUniformInferableQuantizer(num_bits=8,
+                                                                  min_range=[-3.],
+                                                                   max_range=thresholds)
+        self.assertEqual(f"For activation, only per-tensor quantization is supported. Thus, max_range should be of length 1 but is {len(thresholds)}", str(e.exception))
 

--- a/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_activation_quantizers.py
@@ -213,3 +213,8 @@ class TestONNXExportActivationQuantizers(unittest.TestCase):
                                                                    max_range=thresholds)
         self.assertEqual(f"For activation, only per-tensor quantization is supported. Thus, max_range should be of length 1 but is {len(thresholds)}", str(e.exception))
 
+        with self.assertRaises(Exception) as e:
+            pytorch_quantizers.ActivationUniformInferableQuantizer(num_bits=8,
+                                                                  min_range=[-3.],
+                                                                   max_range=[-5.])
+        self.assertEqual(f"Max range must be greater than min value but min is -3.0 and max is -5.0", str(e.exception))

--- a/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
@@ -344,3 +344,16 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                                                 max_range=thresholds)
         self.assertEqual(f"Channel axis is missing in per channel quantization", str(e.exception))
 
+        # Check min > max
+        with self.assertRaises(Exception) as e:
+            pytorch_quantizers.WeightsUniformInferableQuantizer(num_bits=8,
+                                                                  per_channel=per_channel,
+                                                                  min_range=[-3.],
+                                                                max_range=[-5.])
+        self.assertEqual(f"Max range must be greater than min value but min is -3.0 and max is -5.0", str(e.exception))
+        with self.assertRaises(Exception) as e:
+            pytorch_quantizers.WeightsUniformInferableQuantizer(num_bits=8,
+                                                                  per_channel=True,
+                                                                  min_range=[-3., -2.],
+                                                                max_range=[5., -3.])
+        self.assertEqual(f"Max range must be greater than min value but min is -2.0 and max is -3.0", str(e.exception))

--- a/tests/pytorch_tests/quantizers_tests/test_illegal_weights_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_illegal_weights_inferable_quantizer.py
@@ -53,8 +53,8 @@ class TestPytorchWeightsIllegalInferableQuantizers(unittest.TestCase):
 
     def test_zero_not_in_range_uniform_quantizer(self):
         num_bits = 3
-        min_range = np.asarray([-10.7, 2.3, -6.6, 0])
-        max_range = np.asarray([-4.1, 4.7, 20, 7])
+        min_range = [-10.7, 2.3, -6.6, 0]
+        max_range = [-4.1, 4.7, 20, 7]
         quantizer = WeightsUniformInferableQuantizer(num_bits=num_bits,
                                                      per_channel=True,
                                                      min_range=min_range,

--- a/tests/pytorch_tests/quantizers_tests/test_weights_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_weights_inferable_quantizer.py
@@ -174,8 +174,8 @@ class TestPytorchWeightsInferableQuantizers(unittest.TestCase):
 
     def test_uniform_weights_quantizer_per_channel(self):
         num_bits = 3
-        min_range = np.asarray([-10, -3, -8, 0])
-        max_range = np.asarray([4, 4, 20, 7])
+        min_range = [-10, -3, -8, 0]
+        max_range = [4, 4, 20, 7]
         quantizer = WeightsUniformInferableQuantizer(num_bits=num_bits,
                                                      per_channel=True,
                                                      min_range=min_range,
@@ -215,8 +215,8 @@ class TestPytorchWeightsInferableQuantizers(unittest.TestCase):
 
     def test_uniform_weights_quantizer_per_tensor(self):
         num_bits = 3
-        min_range = np.asarray([-10])
-        max_range = np.asarray([4])
+        min_range = [-10]
+        max_range = [4]
         quantizer = WeightsUniformInferableQuantizer(num_bits=num_bits,
                                                      per_channel=False,
                                                      min_range=min_range,

--- a/tests/pytorch_tests/test_pytorch_load_model.py
+++ b/tests/pytorch_tests/test_pytorch_load_model.py
@@ -134,8 +134,8 @@ class TestPytorchLoadModel(unittest.TestCase):
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_weights_uniform(self):
-        min_range = np.asarray([3., 6., 2.])
-        max_range = np.asarray([13., 16., 12.])
+        min_range = [3., 6., 2.]
+        max_range = [13., 16., 12.]
         num_bits = 2
         quantizer = WeightsUniformInferableQuantizer(num_bits=num_bits,
                                                      per_channel=True,


### PR DESCRIPTION
Add validation functions to onnxruntime functions for params validation.
Adjust activation uniform quantization range and add warning.
Assert that min range < max range.
