### PR TITLE
Add custom onnx ops to LUT quantizers + Fix Pytorch LUT apis

### DIFF
--- a/mct_quantizers/common/quant_utils.py
+++ b/mct_quantizers/common/quant_utils.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import numpy as np
 from typing import Tuple
+
+import numpy as np
 
 
 def adjust_range_to_include_zero(range_min: np.ndarray,
@@ -47,3 +48,57 @@ def adjust_range_to_include_zero(range_min: np.ndarray,
     max_range_adj = np.maximum(max_range_adj, 0)
 
     return min_range_adj, max_range_adj
+
+
+def lut_quantizer_np(tensor_data: np.ndarray,
+                     lut_values: np.ndarray,
+                     signed: bool,
+                     threshold: np.ndarray,
+                     lut_values_bitwidth: int,
+                     eps: float,
+                     per_channel: bool,
+                     channel_axis: int,
+                     input_rank: int
+                     ) -> np.ndarray:
+    """
+    Quantize a tensor using a non-uniform quantization based on the pre-defined values.
+    """
+    if per_channel:
+        threshold_target_shape = [1] * input_rank
+        threshold_target_shape[channel_axis] = -1
+        threshold = np.reshape(threshold, threshold_target_shape)
+
+    tensor = int_quantization_with_threshold(tensor_data,
+                                             n_bits=lut_values_bitwidth,
+                                             signed=signed,
+                                             threshold=threshold,
+                                             eps=eps)
+    tensor = np.expand_dims(tensor, axis=-1)
+
+    expanded_lut_values = lut_values.reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
+    lut_values_assignments = np.argmin(np.abs(tensor - expanded_lut_values), axis=-1)
+    centers = lut_values.flatten()[lut_values_assignments]
+
+    quant_tensor = (centers / (2 ** (lut_values_bitwidth - int(signed)))) * threshold
+
+    return quant_tensor
+
+
+def int_quantization_with_threshold(data: np.ndarray,
+                                    n_bits: int,
+                                    signed: bool,
+                                    threshold: np.ndarray,
+                                    eps: float) -> np.ndarray:
+    """
+    Divides data by threshold and quantize it to integers in the quantization range.
+    """
+
+    if signed:
+        clip_max = 2 ** (n_bits - 1) - 1
+        clip_min = -2 ** (n_bits - 1)
+    else:
+        clip_max = 2 ** n_bits - 1
+        clip_min = 0
+
+    return np.clip((data / (threshold + eps)) * (2 ** (n_bits - int(signed))),
+                   clip_min, clip_max)

--- a/mct_quantizers/pytorch/quantizer_utils.py
+++ b/mct_quantizers/pytorch/quantizer_utils.py
@@ -97,7 +97,10 @@ def lut_quantizer(tensor_data: torch.Tensor,
                   signed: bool,
                   threshold: torch.Tensor,
                   lut_values_bitwidth: int,
-                  eps: float) -> torch.Tensor:
+                  eps: float,
+                  per_channel:bool,
+                  channel_axis:int,
+                  input_rank:int) -> torch.Tensor:
     """
     Quantize a tensor using a non-uniform quantization based on the pre-defined values.
     1. Scales tensor_data with the threshold into n-bit quantization range.
@@ -115,6 +118,10 @@ def lut_quantizer(tensor_data: torch.Tensor,
 
     Returns: Quantized tensor.
     """
+    if per_channel:
+        threshold_target_shape = [1] * input_rank
+        threshold_target_shape[channel_axis] = -1
+        threshold = torch.reshape(threshold, threshold_target_shape)
 
     tensor = int_quantization_with_threshold(tensor_data,
                                              n_bits=lut_values_bitwidth,

--- a/mct_quantizers/pytorch/quantizer_utils.py
+++ b/mct_quantizers/pytorch/quantizer_utils.py
@@ -98,9 +98,9 @@ def lut_quantizer(tensor_data: torch.Tensor,
                   threshold: torch.Tensor,
                   lut_values_bitwidth: int,
                   eps: float,
-                  per_channel:bool,
-                  channel_axis:int,
-                  input_rank:int) -> torch.Tensor:
+                  per_channel:bool=None,
+                  channel_axis:int=None,
+                  input_rank:int=None) -> torch.Tensor:
     """
     Quantize a tensor using a non-uniform quantization based on the pre-defined values.
     1. Scales tensor_data with the threshold into n-bit quantization range.

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import List
+
 import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
@@ -35,8 +37,8 @@ if FOUND_TORCH:
 
         def __init__(self,
                      num_bits: int,
-                     lut_values: np.ndarray,
-                     threshold: np.ndarray,
+                     lut_values: List[float],
+                     threshold: List[float],
                      signed: bool,
                      lut_values_bitwidth: int = LUT_VALUES_BITWIDTH,
                      eps: float = EPS):

--- a/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/activation_inferable_quantizers/activation_lut_pot_inferable_quantizer.py
@@ -62,7 +62,7 @@ if FOUND_TORCH:
                 lut_values_bitwidth=lut_values_bitwidth,
                 eps=eps)
 
-            is_threshold_pot = np.all(np.round(np.log2(threshold.flatten())) == np.log2(threshold.flatten()))
+            is_threshold_pot = np.all(np.round(np.log2(self._threshold_np.flatten())) == np.log2(self._threshold_np.flatten()))
             assert is_threshold_pot, f'Expected threshold to be power of 2 but is {threshold}'
 
             # Activation supports only per-tensor quantization
@@ -71,7 +71,7 @@ if FOUND_TORCH:
                                       f'should be of length 1 but is {len(threshold)}'
             self.threshold = self.threshold[0]
 
-            self.lut_values = to_torch_tensor(self.lut_values).to(get_working_device())
+            self.lut_values = to_torch_tensor(self._lut_values_np).to(get_working_device())
 
         def __call__(self, inputs: torch.Tensor):
             """
@@ -83,8 +83,12 @@ if FOUND_TORCH:
             Returns:
                 quantized tensor.
             """
-            return lut_quantizer(inputs, lut_values=self.lut_values, signed=self.signed,
-                                 threshold=self.threshold, lut_values_bitwidth=self.lut_values_bitwidth, eps=self.eps)
+            return lut_quantizer(inputs,
+                                 lut_values=self.lut_values,
+                                 signed=self.signed,
+                                 threshold=self.threshold,
+                                 lut_values_bitwidth=self.lut_values_bitwidth,
+                                 eps=self.eps)
 
 else:
     class ActivationLutPOTInferableQuantizer:  # pragma: no cover

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
@@ -12,17 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import List
 
 import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
-from mct_quantizers.common.constants import FOUND_TORCH, LUT_VALUES_BITWIDTH, EPS
+from mct_quantizers.common.constants import FOUND_TORCH, LUT_VALUES_BITWIDTH, EPS, ONNX_CUSTOM_OP_DOMAIN, \
+    FOUND_ONNXRUNTIME_EXTENSIONS
 from mct_quantizers.common.quant_info import QuantizationMethod
 
 if FOUND_TORCH:
-    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_symmetric_inferable_quantizer \
-        import \
-        WeightsLUTSymmetricInferableQuantizer
+    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_symmetric_inferable_quantizer import \
+    WeightsLUTSymmetricInferableQuantizer, WeightsLUTSymmetricF
+    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.base_weight_quantizer_autograd_function import \
+        BaseWeightQuantizerAutogradFunction
+    import torch
 
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
@@ -35,10 +39,11 @@ if FOUND_TORCH:
 
         def __init__(self,
                      num_bits: int,
-                     lut_values: np.ndarray,
-                     threshold: np.ndarray,
+                     lut_values: List[float],
+                     threshold: List[float],
                      per_channel: bool,
                      channel_axis: int = None,
+                     input_rank: int = None,
                      lut_values_bitwidth: int = LUT_VALUES_BITWIDTH,
                      eps: float = EPS):
             """
@@ -59,11 +64,107 @@ if FOUND_TORCH:
                                                                   lut_values=lut_values,
                                                                   per_channel=per_channel,
                                                                   channel_axis=channel_axis,
+                                                                  input_rank=input_rank,
                                                                   lut_values_bitwidth=lut_values_bitwidth,
                                                                   eps=eps)
-
-            is_threshold_pot = np.all(np.round(np.log2(threshold.flatten())) == np.log2(threshold.flatten()))
+            is_threshold_pot = np.all(np.round(np.log2(self._threshold_np.flatten())) == np.log2(self._threshold_np.flatten()))
             assert is_threshold_pot, f'Expected threshold to be power of 2 but is {threshold}'
+
+
+        def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
+            """
+            Quantize the given inputs using the quantizer parameters.
+
+            Args:
+                inputs: input tensor to quantize
+
+            Returns:
+                quantized tensor.
+            """
+
+            if self._use_custom_impl and torch.jit.is_tracing():
+                return WeightsLUTPOTF.apply(inputs,
+                                            self.num_bits,
+                                            self._lut_values_np,
+                                            self._threshold_np,
+                                            self.lut_values_bitwidth,
+                                            self.eps,
+                                            self.per_channel,
+                                            self.channel_axis,
+                                            self.input_rank
+                                            )
+
+            return super(WeightsLUTPOTInferableQuantizer, self).__call__(inputs)
+
+
+    class WeightsLUTPOTF(BaseWeightQuantizerAutogradFunction):
+        """
+        Custom autograd function for symmetric weights quantizer.
+        It provides a way to define a custom forward and symbolic operation
+        and currently does not implement a backward operation.
+        """
+        @staticmethod
+        def forward(ctx,
+                    input_tensor,
+                    num_bits,
+                    lut_values,
+                    threshold,
+                    lut_values_bitwidth,
+                    eps,
+                    per_channel,
+                    channel_axis,
+                    input_rank
+                    ):
+            return WeightsLUTSymmetricF.forward(ctx,
+                                                input_tensor,
+                                                num_bits,
+                                                lut_values,
+                                                threshold,
+                                                lut_values_bitwidth,
+                                                eps,
+                                                per_channel,
+                                                channel_axis,
+                                                input_rank
+                                                )
+
+        @staticmethod
+        def symbolic(g,
+                     input_tensor,
+                     num_bits,
+                     lut_values,
+                     threshold,
+                     lut_values_bitwidth,
+                     eps,
+                     per_channel,
+                     channel_axis,
+                     input_rank):
+            """
+            Symbolic method that defines the custom operation for ONNX export.
+
+            Args:
+                g: A graph object that represents the ONNX computation graph.
+                input_tensor: The input tensor to be quantized.
+                num_bits: The number of bits to represent the quantized value.
+                threshold: The quantization threshold.
+                per_channel: whether to use per-channel quantization
+                channel_axis: Axis of input to apply per-channel quantization on.
+
+            Returns:
+                The node in the ONNX graph representing the output of this operation.
+            """
+            return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsLUTPOTQuantizer", input_tensor,
+                        g.op('Constant', value_t=torch.tensor(lut_values, dtype=torch.float32)),
+                        g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
+                        num_bits_i=num_bits,
+                        per_channel_i=int(per_channel),
+                        channel_axis_i=channel_axis,
+                        input_rank_i=input_rank,
+                        lut_values_bitwidth_i=lut_values_bitwidth,
+                        eps_f=eps,
+                        signed_i=int(WeightsLUTSymmetricF.is_signed()),
+                        **WeightsLUTSymmetricF._get_metadata_attributes()
+                        ).setType(
+                input_tensor.type())
 
 
 else:
@@ -72,3 +173,35 @@ else:
             raise Exception('Installing torch is mandatory '
                             'when using WeightsLUTPOTInferableQuantizer. '
                             'Could not find torch package.')
+
+
+if FOUND_ONNXRUNTIME_EXTENSIONS:
+    from onnxruntime_extensions import onnx_op, PyCustomOpDef
+    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_symmetric_inferable_quantizer import  quantize_lut_sym_weights_numpy
+
+    # Add onnx op function to use during onnxruntime WeightsLUTPOTQuantizer op inference
+    # Using this decorator the op WeightsLUTPOTQuantizer is defined using its inputs, outputs and attributes.
+    @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsLUTPOTQuantizer",
+             inputs=[PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_float],
+             outputs=[PyCustomOpDef.dt_float],
+             attrs={
+                 "lut_values_bitwidth": PyCustomOpDef.dt_int64,
+                 "eps": PyCustomOpDef.dt_float,
+                 "per_channel": PyCustomOpDef.dt_int64,
+                 "channel_axis": PyCustomOpDef.dt_int64,
+                 "input_rank": PyCustomOpDef.dt_int64
+             })
+    def weight_lut_sym_ort(input_tensor: np.ndarray,
+                           lut_values: np.ndarray,
+                           threshold: np.ndarray,
+                           **kwargs):
+        return quantize_lut_sym_weights_numpy(input_tensor,
+                                              lut_values,
+                                              threshold,
+                                              kwargs["lut_values_bitwidth"],
+                                              kwargs["eps"],
+                                              kwargs["per_channel"],
+                                              kwargs["channel_axis"],
+                                              kwargs["input_rank"])

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
@@ -161,8 +161,8 @@ if FOUND_TORCH:
                         input_rank_i=input_rank,
                         lut_values_bitwidth_i=lut_values_bitwidth,
                         eps_f=eps,
-                        signed_i=int(WeightsLUTSymmetricF.is_signed()),
-                        **WeightsLUTSymmetricF._get_metadata_attributes()
+                        signed_i=int(WeightsLUTPOTF.is_signed()),
+                        **WeightsLUTPOTF._get_metadata_attributes()
                         ).setType(
                 input_tensor.type())
 

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
@@ -12,18 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import List
 
 import numpy as np
 
 from mct_quantizers.common.base_inferable_quantizer import mark_quantizer, QuantizationTarget, QuantizerID
-from mct_quantizers.common.constants import FOUND_TORCH, LUT_VALUES_BITWIDTH, EPS
+from mct_quantizers.common.constants import FOUND_TORCH, LUT_VALUES_BITWIDTH, EPS, ONNX_CUSTOM_OP_DOMAIN, \
+    FOUND_ONNXRUNTIME_EXTENSIONS
 from mct_quantizers.common.quant_info import QuantizationMethod
+from mct_quantizers.common.quant_utils import lut_quantizer_np
 
 if FOUND_TORCH:
     import torch
     from mct_quantizers.pytorch.quantizer_utils import to_torch_tensor, get_working_device, lut_quantizer
     from mct_quantizers.pytorch.quantizers.base_lut_symmetric_inferable_quantizer import \
         BaseLUTSymmetricInferableQuantizer
+    from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.base_weight_quantizer_autograd_function import \
+        BaseWeightQuantizerAutogradFunction
 
 
     @mark_quantizer(quantization_target=QuantizationTarget.Weights,
@@ -36,10 +41,11 @@ if FOUND_TORCH:
 
         def __init__(self,
                      num_bits: int,
-                     lut_values: np.ndarray,
-                     threshold: np.ndarray,
+                     lut_values: List[float],
+                     threshold: List[float],
                      per_channel: bool,
                      channel_axis: int = None,
+                     input_rank: int = None,
                      lut_values_bitwidth: int = LUT_VALUES_BITWIDTH,
                      eps: float = EPS):
             """
@@ -62,8 +68,13 @@ if FOUND_TORCH:
                                                                         lut_values_bitwidth=lut_values_bitwidth,
                                                                         eps=eps)
 
+            self.per_channel = per_channel
+            self.channel_axis = channel_axis
+            self.input_rank = input_rank
+
             if per_channel:
                 assert channel_axis is not None, f'Channel axis is missing in per channel quantization'
+                assert input_rank is not None, f'input_rank is missing in per channel quantization'
                 assert len(
                     threshold) >= 1, f'In per-channel quantization threshold should be of length >= 1 but is ' \
                                      f'{len(threshold)}'
@@ -72,11 +83,8 @@ if FOUND_TORCH:
                     threshold) == 1, f'In per-tensor quantization threshold should be of length 1 but is ' \
                                      f'{len(threshold)}'
 
-            self.per_channel = per_channel
-            self.channel_axis = channel_axis
-
-            self.threshold = to_torch_tensor(self.threshold).to(get_working_device())
-            self.lut_values = to_torch_tensor(self.lut_values).to(get_working_device())
+            self._threshold_torch = to_torch_tensor(self._threshold_np).to(get_working_device())
+            self._lut_values_torch = to_torch_tensor(self._lut_values_np).to(get_working_device())
 
         def __call__(self, inputs: torch.Tensor) -> torch.Tensor:
             """
@@ -88,9 +96,97 @@ if FOUND_TORCH:
             Returns:
                 quantized tensor.
             """
+            if self._use_custom_impl and torch.jit.is_tracing():
+                return WeightsLUTSymmetricF.apply(inputs,
+                                                  self.num_bits,
+                                                  self._lut_values_np,
+                                                  self._threshold_np,
+                                                  self.lut_values_bitwidth,
+                                                  self.eps,
+                                                  self.per_channel,
+                                                  self.channel_axis,
+                                                  self.input_rank
+                                                  )
+
             inputs.requires_grad = False
-            return lut_quantizer(inputs, lut_values=self.lut_values, signed=True,
-                                 threshold=self.threshold, lut_values_bitwidth=self.lut_values_bitwidth, eps=self.eps)
+            return lut_quantizer(inputs,
+                                 lut_values=self.lut_values,
+                                 signed=True,
+                                 threshold=self.threshold,
+                                 lut_values_bitwidth=self.lut_values_bitwidth,
+                                 eps=self.eps,
+                                 per_channel=self.per_channel,
+                                 channel_axis=self.channel_axis,
+                                 input_rank=self.input_rank
+                                 )
+
+
+    class WeightsLUTSymmetricF(BaseWeightQuantizerAutogradFunction):
+        """
+        Custom autograd function for symmetric weights quantizer.
+        It provides a way to define a custom forward and symbolic operation
+        and currently does not implement a backward operation.
+        """
+
+        @staticmethod
+        def forward(ctx, input_tensor, num_bits, lut_values, threshold, lut_values_bitwidth, eps,
+                    per_channel,
+                    channel_axis,
+                    input_rank
+                    ):
+            # Apply pass np arrays to support the symbolic op, so it needs to be converted to
+            # torch since here we quantize a torch tensor
+            threshold_torch = to_torch_tensor(threshold).to(get_working_device())
+            lut_values_torch = to_torch_tensor(lut_values).to(get_working_device())
+
+            return lut_quantizer(input_tensor,
+                                 lut_values=lut_values_torch,
+                                 signed=True,
+                                 threshold=threshold_torch,
+                                 lut_values_bitwidth=lut_values_bitwidth,
+                                 eps=eps,
+                                 per_channel=per_channel,
+                                 channel_axis=channel_axis,
+                                 input_rank=input_rank)
+
+        @staticmethod
+        def symbolic(g,
+                     input_tensor,
+                     num_bits,
+                     lut_values,
+                     threshold,
+                     lut_values_bitwidth,
+                     eps,
+                     per_channel,
+                     channel_axis,
+                     input_rank):
+            """
+            Symbolic method that defines the custom operation for ONNX export.
+
+            Args:
+                g: A graph object that represents the ONNX computation graph.
+                input_tensor: The input tensor to be quantized.
+                num_bits: The number of bits to represent the quantized value.
+                threshold: The quantization threshold.
+                per_channel: whether to use per-channel quantization
+                channel_axis: Axis of input to apply per-channel quantization on.
+
+            Returns:
+                The node in the ONNX graph representing the output of this operation.
+            """
+            return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsLUTSymmetricQuantizer", input_tensor,
+                        g.op('Constant', value_t=torch.tensor(lut_values, dtype=torch.float32)),
+                        g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
+                        num_bits_i=num_bits,
+                        per_channel_i=int(per_channel),
+                        channel_axis_i=channel_axis,
+                        input_rank_i=input_rank,
+                        lut_values_bitwidth_i=lut_values_bitwidth,
+                        eps_f=eps,
+                        signed_i=int(WeightsLUTSymmetricF.is_signed()),
+                        **WeightsLUTSymmetricF._get_metadata_attributes()
+                        ).setType(
+                input_tensor.type())
 
 
 else:
@@ -99,3 +195,53 @@ else:
             raise Exception('Installing torch is mandatory '
                             'when using WeightsLUTSymmetricInferableQuantizer. '
                             'Could not find torch package.')
+
+if FOUND_ONNXRUNTIME_EXTENSIONS:
+    from onnxruntime_extensions import onnx_op, PyCustomOpDef
+    def quantize_lut_sym_weights_numpy(input_tensor: np.ndarray,
+                                       lut_values,
+                                       threshold,
+                                       lut_values_bitwidth,
+                                       eps,
+                                       per_channel,
+                                       channel_axis,
+                                       input_rank
+                                       ):
+        quantized_tensor = lut_quantizer_np(tensor_data=input_tensor,
+                                            lut_values=lut_values,
+                                            signed=True,
+                                            threshold=threshold,
+                                            lut_values_bitwidth=lut_values_bitwidth,
+                                            eps=eps,
+                                            per_channel=per_channel,
+                                            channel_axis=channel_axis,
+                                            input_rank=input_rank)
+        return quantized_tensor
+
+
+    # Add onnx op function to use during onnxruntime WeightsLUTSymmetricQuantizer op inference
+    # Using this decorator the op WeightsLUTSymmetricQuantizer is defined using its inputs, outputs and attributes.
+    @onnx_op(op_type=f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsLUTSymmetricQuantizer",
+             inputs=[PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_float,
+                     PyCustomOpDef.dt_float],
+             outputs=[PyCustomOpDef.dt_float],
+             attrs={
+                 "lut_values_bitwidth": PyCustomOpDef.dt_int64,
+                 "eps": PyCustomOpDef.dt_float,
+                 "per_channel": PyCustomOpDef.dt_int64,
+                 "channel_axis": PyCustomOpDef.dt_int64,
+                 "input_rank": PyCustomOpDef.dt_int64
+             })
+    def weight_lut_sym_ort(input_tensor: np.ndarray,
+                           lut_values: np.ndarray,
+                           threshold: np.ndarray,
+                           **kwargs):
+        return quantize_lut_sym_weights_numpy(input_tensor,
+                                              lut_values,
+                                              threshold,
+                                              kwargs["lut_values_bitwidth"],
+                                              kwargs["eps"],
+                                              kwargs["per_channel"],
+                                              kwargs["channel_axis"],
+                                              kwargs["input_rank"])

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
@@ -110,9 +110,9 @@ if FOUND_TORCH:
 
             inputs.requires_grad = False
             return lut_quantizer(inputs,
-                                 lut_values=self.lut_values,
+                                 lut_values=self._lut_values_torch,
                                  signed=True,
-                                 threshold=self.threshold,
+                                 threshold=self._threshold_torch,
                                  lut_values_bitwidth=self.lut_values_bitwidth,
                                  eps=self.eps,
                                  per_channel=self.per_channel,

--- a/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
@@ -26,8 +26,8 @@ from onnx import numpy_helper
 from mct_quantizers import PytorchQuantizationWrapper
 from mct_quantizers import get_ort_session_options
 from mct_quantizers import pytorch_quantizers
-from mct_quantizers.common.constants import MCTQ_VERSION
-from mct_quantizers.pytorch.quantizer_utils import get_working_device
+from mct_quantizers.common.constants import MCTQ_VERSION, EPS
+from mct_quantizers.pytorch.quantizer_utils import get_working_device, lut_quantizer, to_torch_tensor
 from tests.pytorch_tests.onnx_export_tests.test_activation_quantizers import _export_model, _check_load_and_inference, _get_qparams_from_attributes_for_single_quantizer, _get_qparams_from_input_tensors_for_single_quantizer
 
 
@@ -357,3 +357,66 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
                                                                   min_range=[-3., -2.],
                                                                 max_range=[5., -3.])
         self.assertEqual(f"Max range must be greater than min value but min is -2.0 and max is -3.0", str(e.exception))
+
+
+
+
+    def test_onnx_weight_lut_pot(self):
+        self.test_onnx_weight_lut_sym(threshold=[2., 8., 0.5],
+                                      quantizer_type=pytorch_quantizers.WeightsLUTPOTInferableQuantizer,
+                                      onnx_op_name='WeightsLUTPOTQuantizer')
+
+
+    def test_onnx_weight_lut_sym(self,
+                                 threshold = [3., 8., 7.],
+                                 quantizer_type=pytorch_quantizers.WeightsLUTSymmetricInferableQuantizer,
+                                 onnx_op_name='WeightsLUTSymmetricQuantizer'):
+        lut_values = [-25, 25]
+        per_channel = True
+        num_bits = 3
+        # test per channel
+        channel_axis = 3
+        lut_values_bitwidth = 8
+        input_rank = 4
+        quantizer=quantizer_type(num_bits=num_bits,
+                                lut_values=lut_values,
+                                threshold=threshold,
+                                per_channel=per_channel,
+                                channel_axis=channel_axis,
+                                lut_values_bitwidth=lut_values_bitwidth,
+                                input_rank=input_rank)
+        quantizer.enable_custom_impl()
+
+        layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 4, 3),
+                                                          {'weight': quantizer}).to(self.device)
+
+        _, onnx_file_path = tempfile.mkstemp('.onnx')
+        _export_model(layer_with_quantizer,
+                      onnx_file_path,
+                      torch.rand(1, 3, 8, 8).to(self.device))
+
+        _check_load_and_inference(onnx_file_path)
+
+        node_qparams = _get_qparams_from_input_tensors_for_single_quantizer(onnx_file_path, onnx_op_name)
+        lut_values_onnx = node_qparams[0]
+        threshold_onnx = node_qparams[1]
+        assert np.all(lut_values_onnx==lut_values), f'Expected lut_values in quantizer to be {lut_values} but found {lut_values_onnx}'
+        assert np.all(threshold_onnx==threshold), f'Expected threshold in quantizer to be {threshold} but found {threshold_onnx}'
+
+        node_qparams = _get_qparams_from_attributes_for_single_quantizer(onnx_file_path, onnx_op_name)
+        onnx_nbits = node_qparams['num_bits']
+        onnx_per_channel = node_qparams['per_channel']
+        onnx_channel_axis = node_qparams['channel_axis']
+        onnx_eps = node_qparams['eps']
+        onnx_input_rank = node_qparams['input_rank']
+        onnx_signed = node_qparams['signed']
+        onnx_lut_values_bitwidth = node_qparams['lut_values_bitwidth']
+
+        assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
+        assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
+        assert onnx_channel_axis == channel_axis, f'Expected channel_axis in quantizer to be {channel_axis} but found {onnx_channel_axis}'
+        assert np.isclose(onnx_eps, EPS), f'Expected eps in quantizer to be {EPS} but found {onnx_eps}'
+        assert onnx_input_rank == input_rank, f'Expected input_rank in quantizer to be {input_rank} but found {onnx_input_rank}'
+        assert onnx_lut_values_bitwidth == lut_values_bitwidth, f'Expected lut_values_bitwidth in quantizer to be {lut_values_bitwidth} but found {onnx_lut_values_bitwidth}'
+        assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
+        assert node_qparams[MCTQ_VERSION] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams[MCTQ_VERSION]}'

--- a/tests/pytorch_tests/quantizers_tests/test_activation_lut_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_activation_lut_inferable_quantizer.py
@@ -25,8 +25,8 @@ from mct_quantizers.pytorch.quantizers.activation_inferable_quantizers.activatio
 class TestKerasActivationLutPotQuantizer(unittest.TestCase):
 
     def test_lut_pot_signed_quantizer(self):
-        lut_values = np.asarray([-25, 25])
-        thresholds = np.asarray([4.])
+        lut_values = [-25, 25]
+        thresholds = [4.]
         num_bits = 3
         signed = True
         lut_values_bitwidth = 8
@@ -60,7 +60,7 @@ class TestKerasActivationLutPotQuantizer(unittest.TestCase):
                                   f'Quantized tensor expected to have no more than {2 ** num_bits} unique values but has '
                                   f'{len(np.unique(fake_quantized_tensor))} unique values')
 
-        quant_tensor_values = lut_values / (2 ** (lut_values_bitwidth - int(signed))) * thresholds
+        quant_tensor_values = np.asarray(lut_values) / (2 ** (lut_values_bitwidth - int(signed))) * np.asarray(thresholds)
         self.assertTrue(len(np.unique(fake_quantized_tensor)) <= 2 ** num_bits,
                                   f'Quantized tensor expected to have no more than {2 ** num_bits} unique values but has '
                                   f'{len(np.unique(fake_quantized_tensor))} unique values')
@@ -71,12 +71,12 @@ class TestKerasActivationLutPotQuantizer(unittest.TestCase):
         clip_max = 2 ** (lut_values_bitwidth - 1) - 1
         clip_min = -2 ** (lut_values_bitwidth - 1)
 
-        tensor = torch.clip((input_tensor / thresholds) * (2 ** (lut_values_bitwidth - int(signed))),
+        tensor = torch.clip((input_tensor / np.asarray(thresholds)) * (2 ** (lut_values_bitwidth - int(signed))),
                             min=clip_min, max=clip_max)
         tensor = tensor.unsqueeze(-1)
-        expanded_lut_values = lut_values.reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
+        expanded_lut_values = np.asarray(lut_values).reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
         lut_values_assignments = torch.argmin(torch.abs(tensor - expanded_lut_values), dim=-1)
-        centers = lut_values.flatten()[lut_values_assignments]
+        centers = np.asarray(lut_values).flatten()[lut_values_assignments]
 
         self.assertTrue(np.all(centers / (2 ** (lut_values_bitwidth - int(signed))) * thresholds ==
                                          fake_quantized_tensor), "Quantized tensor values weren't assigned correctly")
@@ -86,8 +86,8 @@ class TestKerasActivationLutPotQuantizer(unittest.TestCase):
                                   f'Expected some values to be negative but quantized tensor is {fake_quantized_tensor}')
 
     def test_lut_pot_unsigned_quantizer(self):
-        lut_values = np.asarray([25, 45])
-        thresholds = np.asarray([4.])
+        lut_values = [25, 45]
+        thresholds = [4.]
         num_bits = 3
         signed = False
         lut_values_bitwidth = 7
@@ -120,7 +120,7 @@ class TestKerasActivationLutPotQuantizer(unittest.TestCase):
                                   f'Quantized tensor expected to have no more than {2 ** num_bits} unique values but has '
                                   f'{len(np.unique(fake_quantized_tensor))} unique values')
 
-        quant_tensor_values = lut_values / (2 ** (lut_values_bitwidth - int(signed))) * thresholds
+        quant_tensor_values = np.asarray(lut_values) / (2 ** (lut_values_bitwidth - int(signed))) * np.asarray(thresholds)
         self.assertTrue(len(np.unique(fake_quantized_tensor)) <= 2 ** num_bits,
                                   f'Quantized tensor expected to have no more than {2 ** num_bits} unique values but has '
                                   f'{len(np.unique(fake_quantized_tensor))} unique values')
@@ -131,12 +131,12 @@ class TestKerasActivationLutPotQuantizer(unittest.TestCase):
         clip_max = 2 ** lut_values_bitwidth - 1
         clip_min = 0
 
-        tensor = torch.clip((input_tensor / thresholds) * (2 ** (lut_values_bitwidth - int(signed))),
+        tensor = torch.clip((input_tensor / np.asarray(thresholds)) * (2 ** (lut_values_bitwidth - int(signed))),
                             min=clip_min, max=clip_max)
         tensor = tensor.unsqueeze(-1)
-        expanded_lut_values = lut_values.reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
+        expanded_lut_values = np.asarray(lut_values).reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
         lut_values_assignments = torch.argmin(torch.abs(tensor - expanded_lut_values), dim=-1)
-        centers = lut_values.flatten()[lut_values_assignments]
+        centers = np.asarray(lut_values).flatten()[lut_values_assignments]
 
         self.assertTrue(np.all(centers / (2 ** (lut_values_bitwidth - int(signed))) * thresholds ==
                                          fake_quantized_tensor), "Quantized tensor values weren't assigned correctly")

--- a/tests/pytorch_tests/quantizers_tests/test_illegal_activation_lut_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_illegal_activation_lut_inferable_quantizer.py
@@ -26,9 +26,9 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
     def test_illegal_pot_lut_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               lut_values=np.asarray([25., 85.]),
+                                               lut_values=[25., 85.],
                                                # Not POT threshold
-                                               threshold=np.asarray([3]),
+                                               threshold=[3],
                                                signed=True)
         self.assertEqual('Expected threshold to be power of 2 but is [3]', str(e.exception))
 
@@ -39,24 +39,24 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
                                                threshold=4,
                                                signed=True)
 
-        self.assertEqual('Threshold is expected to be numpy array, but is of type <class \'int\'>',
+        self.assertEqual('Threshold is expected to be a list, but is of type <class \'int\'>',
                                    str(e.exception))
 
     def test_illegal_signed_lut_values_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               lut_values=np.asarray([-25., 85.]),
-                                               threshold=np.asarray([2.]),
+                                               lut_values=[-25., 85.],
+                                               threshold=[2.],
                                                signed=False)
         self.assertEqual('Expected unsigned lut values in unsigned activation quantization',
                                    str(e.exception))
 
     def test_illegal_num_of_lut_values_quantizer(self):
-        lut_values = np.asarray([-25, 25, 3, 19, 55])
+        lut_values = [-25, 25, 3, 19, 55]
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=2,
                                                lut_values=lut_values,
-                                               threshold=np.asarray([2.]),
+                                               threshold=[2.],
                                                signed=False)
         self.assertEqual(f'Expected num of lut values to be less or equal than {2 ** 2} but got '
                                    f'{len(lut_values)}', str(e.exception))
@@ -64,16 +64,16 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
     def test_illegal_lut_values_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               lut_values=np.asarray([-25.6, 25]),
-                                               threshold=np.asarray([2.]),
+                                               lut_values=[-25.6, 25],
+                                               threshold=[2.],
                                                signed=False)
         self.assertEqual('Expected lut values to be integers', str(e.exception))
 
     def test_illegal_lut_values_signed_range_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=3,
-                                               lut_values=np.asarray([-25, 25]),
-                                               threshold=np.asarray([2.]),
+                                               lut_values=[-25, 25],
+                                               threshold=[2.],
                                                signed=True,
                                                lut_values_bitwidth=5)
         self.assertEqual('Expected lut values in the quantization range', str(e.exception))
@@ -81,8 +81,8 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
     def test_illegal_lut_values_unsigned_range_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=3,
-                                               lut_values=np.asarray([15, 25]),
-                                               threshold=np.asarray([2.]),
+                                               lut_values=[15, 25],
+                                               threshold=[2.],
                                                signed=False,
                                                lut_values_bitwidth=4)
         self.assertEqual('Expected lut values in the quantization range', str(e.exception))
@@ -90,8 +90,8 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
     def test_illegal_num_bit_bigger_than_lut_values_bitwidth_quantizer(self):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=10,
-                                               lut_values=np.asarray([-25, 25]),
-                                               threshold=np.asarray([2.]),
+                                               lut_values=[-25, 25],
+                                               threshold=[2.],
                                                signed=True,
                                                lut_values_bitwidth=8)
         self.assertEqual('Look-Up-Table bit configuration has 10 bits. It must be less then 8',
@@ -100,8 +100,8 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
     def test_warning_num_bit_equal_lut_values_bitwidth_quantizer(self):
         with warnings.catch_warnings(record=True) as w:
             ActivationLutPOTInferableQuantizer(num_bits=8,
-                                               lut_values=np.asarray([-25, 25]),
-                                               threshold=np.asarray([2.]),
+                                               lut_values=[-25, 25],
+                                               threshold=[2.],
                                                signed=True,
                                                lut_values_bitwidth=8)
         self.assertTrue(
@@ -113,28 +113,18 @@ class TestPytorchActivationIllegalLutPotQuantizer(unittest.TestCase):
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=3,
                                                lut_values=np.asarray([-25, 25]),
-                                               threshold=[2.],
+                                               threshold=2.,
                                                signed=True,
                                                lut_values_bitwidth=8)
-        self.assertEqual('Threshold is expected to be numpy array, but is of type <class \'list\'>',
+        self.assertEqual('Threshold is expected to be a list, but is of type <class \'float\'>',
                                    str(e.exception))
 
-    def test_illegal_threshold_shape_quantizer(self):
-        threshold = np.array([[4., 2.], [2., 16.]])
-        with self.assertRaises(Exception) as e:
-            ActivationLutPOTInferableQuantizer(num_bits=3,
-                                               lut_values=np.asarray([-25, 25]),
-                                               threshold=threshold,
-                                               signed=True,
-                                               lut_values_bitwidth=8)
-        self.assertEqual(f'Threshold is expected to be flatten, but of shape {threshold.shape}',
-                                   str(e.exception))
 
     def test_illegal_num_of_thresholds_quantizer(self):
-        threshold = np.asarray([1., 4.])
+        threshold = [1., 4.]
         with self.assertRaises(Exception) as e:
             ActivationLutPOTInferableQuantizer(num_bits=3,
-                                               lut_values=np.asarray([-25, 25]),
+                                               lut_values=[-25, 25],
                                                threshold=threshold,
                                                signed=True,
                                                lut_values_bitwidth=8)

--- a/tests/pytorch_tests/quantizers_tests/test_illegal_weights_lut_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_illegal_weights_lut_inferable_quantizer.py
@@ -109,7 +109,7 @@ class BasePytorchWeightsIllegalLutQuantizerTest(unittest.TestCase):
                                 lut_values=lut_values,
                                 threshold=threshold,
                                 channel_axis=channel_axis)
-        self.assertEqual('Threshold is expected to be numpy array, but is of type <class \'list\'>',
+        self.assertEqual('Threshold is expected to be a list, but is of type <class \'numpy.ndarray\'>',
                          str(e.exception))
 
 
@@ -174,7 +174,7 @@ class TestPytorchWeightsIllegalSymmetricLutQuantizer(BasePytorchWeightsIllegalLu
 
     def test_illegal_threshold_type_symmetric_lut_quantizer(self):
         self.illegal_threshold_type_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
-                                                             threshold=[3., 2.],
+                                                             threshold=np.asarray([3., 2.]),
                                                              lut_values=[-25, 25],
                                                              per_channel=False,
                                                              channel_axis=None)

--- a/tests/pytorch_tests/quantizers_tests/test_illegal_weights_lut_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_illegal_weights_lut_inferable_quantizer.py
@@ -112,16 +112,6 @@ class BasePytorchWeightsIllegalLutQuantizerTest(unittest.TestCase):
         self.assertEqual('Threshold is expected to be numpy array, but is of type <class \'list\'>',
                          str(e.exception))
 
-    def illegal_threshold_shape_inferable_quantizer_test(self, inferable_quantizer, threshold, lut_values,
-                                                         per_channel, channel_axis):
-        with self.assertRaises(Exception) as e:
-            inferable_quantizer(num_bits=8,
-                                per_channel=per_channel,
-                                lut_values=lut_values,
-                                threshold=threshold,
-                                channel_axis=channel_axis)
-        self.assertEqual(f'Threshold is expected to be flatten, but of shape {threshold.shape}',
-                         str(e.exception))
 
     def missing_channel_axis_inferable_quantizer(self, inferable_quantizer, threshold, lut_values,
                                                  per_channel):
@@ -142,22 +132,22 @@ class TestPytorchWeightsIllegalSymmetricLutQuantizer(BasePytorchWeightsIllegalLu
 
     def test_illegal_lut_values_symmetric_lut_quantizer(self):
         self.illegal_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
-                                                              threshold=np.asarray([2.]),
-                                                              lut_values=np.asarray([-25.6, 25]),
+                                                              threshold=[2.],
+                                                              lut_values=[-25.6, 25],
                                                               per_channel=False,
                                                               channel_axis=None)
 
     def test_illegal_num_of_lut_values_symmetric_lut_quantizer(self):
         self.illegal_num_of_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
-                                                                     threshold=np.asarray([2.]),
-                                                                     lut_values=np.asarray([-25, 25, 3, 19, 55]),
+                                                                     threshold=[2.],
+                                                                     lut_values=[-25, 25, 3, 19, 55],
                                                                      per_channel=False,
                                                                      channel_axis=None)
 
     def test_illegal_lut_values_range_symmetric_lut_quantizer(self):
         self.illegal_lut_values_range_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
-                                                                    threshold=np.asarray([2.]),
-                                                                    lut_values=np.asarray([-25, 25]),
+                                                                    threshold=[2.],
+                                                                    lut_values=[-25, 25],
                                                                     per_channel=False,
                                                                     channel_axis=None,
                                                                     lut_values_bitwidth=5)
@@ -165,8 +155,8 @@ class TestPytorchWeightsIllegalSymmetricLutQuantizer(BasePytorchWeightsIllegalLu
     def test_illegal_num_bit_bigger_than_lut_values_bitwidth_symmetric_lut_quantizer(self):
         self.illegal_num_bit_bigger_than_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
-            threshold=np.asarray([2.]),
-            lut_values=np.asarray([-25, 25]),
+            threshold=[2.],
+            lut_values=[-25, 25],
             per_channel=False,
             channel_axis=None,
             lut_values_bitwidth=8,
@@ -175,8 +165,8 @@ class TestPytorchWeightsIllegalSymmetricLutQuantizer(BasePytorchWeightsIllegalLu
     def test_warning_num_bit_equal_lut_values_bitwidth_symmetric_lut_quantizer(self):
         self.warning_num_bit_equal_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
-            threshold=np.asarray([2.]),
-            lut_values=np.asarray([-25, 25]),
+            threshold=[2.],
+            lut_values=[-25, 25],
             per_channel=False,
             channel_axis=None,
             lut_values_bitwidth=8,
@@ -185,28 +175,21 @@ class TestPytorchWeightsIllegalSymmetricLutQuantizer(BasePytorchWeightsIllegalLu
     def test_illegal_threshold_type_symmetric_lut_quantizer(self):
         self.illegal_threshold_type_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
                                                              threshold=[3., 2.],
-                                                             lut_values=np.asarray([-25, 25]),
+                                                             lut_values=[-25, 25],
                                                              per_channel=False,
                                                              channel_axis=None)
 
-    def test_illegal_threshold_shape_symmetric_lut_quantizer(self):
-        self.illegal_threshold_shape_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
-                                                              threshold=np.array([[3., 2.], [2., 5.]]),
-                                                              lut_values=np.asarray([-25, 25]),
-                                                              per_channel=False,
-                                                              channel_axis=None)
-
     def test_illegal_num_of_thresholds_symmetric_lut_quantizer(self):
         self.illegal_num_of_thresholds_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
-                                                                threshold=np.asarray([2., 7.]),
-                                                                lut_values=np.asarray([-25, 25]),
+                                                                threshold=[2., 7.],
+                                                                lut_values=[-25, 25],
                                                                 per_channel=False,
                                                                 channel_axis=None)
 
     def test_missing_channel_axis_symmetric_lut_quantizer(self):
         self.missing_channel_axis_inferable_quantizer(inferable_quantizer=self.inferable_quantizer,
-                                                      threshold=np.asarray([2.]),
-                                                      lut_values=np.asarray([-25, 25]),
+                                                      threshold=[2.],
+                                                      lut_values=[-25, 25],
                                                       per_channel=True)
 
 
@@ -220,39 +203,39 @@ class TestPytorchWeightsIllegalPotLutQuantizer(BasePytorchWeightsIllegalLutQuant
     def test_threshold_not_pot_lut_quantizer(self):
         with self.assertRaises(Exception) as e:
             self.inferable_quantizer(num_bits=8,
-                                     lut_values=np.asarray([25., 85.]),
+                                     lut_values=[25., 85.],
                                      per_channel=False,
                                      # Not POT threshold
-                                     threshold=np.asarray([3]))
+                                     threshold=[3])
         self.assertEqual('Expected threshold to be power of 2 but is [3]', str(e.exception))
 
         with self.assertRaises(Exception) as e:
             self.inferable_quantizer(num_bits=8,
-                                     lut_values=np.asarray([25., 85.]),
+                                     lut_values=[25., 85.],
                                      per_channel=False,
                                      # More than one threshold in per-tensor quantization
-                                     threshold=np.asarray([2, 3]))
+                                     threshold=[2, 3])
         self.assertEqual('In per-tensor quantization threshold should be of length 1 but is 2',
                          str(e.exception))
 
     def test_illegal_lut_values_pot_lut_quantizer(self):
         self.illegal_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
-                                                              threshold=np.asarray([2.]),
-                                                              lut_values=np.asarray([-25.6, 25]),
+                                                              threshold=[2.],
+                                                              lut_values=[-25.6, 25],
                                                               per_channel=False,
                                                               channel_axis=None)
 
     def test_illegal_num_of_lut_values_pot_lut_quantizer(self):
         self.illegal_num_of_lut_values_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
-                                                                     threshold=np.asarray([2.]),
-                                                                     lut_values=np.asarray([-25, 25, 3, 19, 55]),
+                                                                     threshold=[2.],
+                                                                     lut_values=[-25, 25, 3, 19, 55],
                                                                      per_channel=False,
                                                                      channel_axis=None)
 
     def test_illegal_lut_values_range_pot_lut_quantizer(self):
         self.illegal_lut_values_range_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
-                                                                    threshold=np.asarray([2.]),
-                                                                    lut_values=np.asarray([-25, 25]),
+                                                                    threshold=[2.],
+                                                                    lut_values=[-25, 25],
                                                                     per_channel=False,
                                                                     channel_axis=None,
                                                                     lut_values_bitwidth=5)
@@ -260,8 +243,8 @@ class TestPytorchWeightsIllegalPotLutQuantizer(BasePytorchWeightsIllegalLutQuant
     def test_illegal_num_bit_bigger_than_lut_values_bitwidth_pot_lut_quantizer(self):
         self.illegal_num_bit_bigger_than_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
-            threshold=np.asarray([2.]),
-            lut_values=np.asarray([-25, 25]),
+            threshold=[2.],
+            lut_values=[-25, 25],
             per_channel=False,
             channel_axis=None,
             lut_values_bitwidth=8,
@@ -270,8 +253,8 @@ class TestPytorchWeightsIllegalPotLutQuantizer(BasePytorchWeightsIllegalLutQuant
     def test_warning_num_bit_equal_lut_values_bitwidth_pot_lut_quantizer(self):
         self.warning_num_bit_equal_lut_values_bitwidth_inferable_quantizer_test(
             inferable_quantizer=self.inferable_quantizer,
-            threshold=np.asarray([2.]),
-            lut_values=np.asarray([-25, 25]),
+            threshold=[2.],
+            lut_values=[-25, 25],
             per_channel=False,
             channel_axis=None,
             lut_values_bitwidth=8,
@@ -284,22 +267,15 @@ class TestPytorchWeightsIllegalPotLutQuantizer(BasePytorchWeightsIllegalLutQuant
                                                              per_channel=False,
                                                              channel_axis=None)
 
-    def test_illegal_threshold_shape_pot_lut_quantizer(self):
-        self.illegal_threshold_shape_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
-                                                              threshold=np.array([[4., 2.], [2., 8.]]),
-                                                              lut_values=np.asarray([-25, 25]),
-                                                              per_channel=False,
-                                                              channel_axis=None)
-
     def test_illegal_num_of_thresholds_pot_lut_quantizer(self):
         self.illegal_num_of_thresholds_inferable_quantizer_test(inferable_quantizer=self.inferable_quantizer,
-                                                                threshold=np.asarray([2., 8.]),
-                                                                lut_values=np.asarray([-25, 25]),
+                                                                threshold=[2., 8.],
+                                                                lut_values=[-25, 25],
                                                                 per_channel=False,
                                                                 channel_axis=None)
 
     def test_missing_channel_axis_pot_lut_quantizer(self):
         self.missing_channel_axis_inferable_quantizer(inferable_quantizer=self.inferable_quantizer,
-                                                      threshold=np.asarray([2.]),
-                                                      lut_values=np.asarray([-25, 25]),
+                                                      threshold=[2.],
+                                                      lut_values=[-25, 25],
                                                       per_channel=True)

--- a/tests/pytorch_tests/quantizers_tests/test_weights_lut_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_weights_lut_inferable_quantizer.py
@@ -25,7 +25,7 @@ from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_
 class TestPytorchWeightsLutQuantizers(unittest.TestCase):
 
     def _weights_lut_quantizer_test(self, inferable_quantizer, num_bits, threshold, lut_values,
-                                    per_channel, channel_axis, lut_values_bitwidth, input_rank):
+                                    per_channel, channel_axis, lut_values_bitwidth, input_rank=None):
         quantizer = inferable_quantizer(num_bits=num_bits,
                                         per_channel=per_channel,
                                         lut_values=lut_values,
@@ -61,7 +61,13 @@ class TestPytorchWeightsLutQuantizers(unittest.TestCase):
 
         if per_channel:
             for i in range(len(threshold)):
-                channel_slice_i = fake_quantized_tensor[:, :, :, i]
+                # Initialize a tuple with slice(None) for each dimension
+                slices = [slice(None)] * fake_quantized_tensor.ndim
+                # Replace the slice at the dimension you want to slice with the index you want
+                slices[channel_axis] = i
+                # Convert the list of slices to a tuple and index into the array
+                channel_slice_i = fake_quantized_tensor[tuple(slices)]
+                # channel_slice_i = fake_quantized_tensor[:, :, :, i]
                 channel_quant_tensor_values = np.asarray(lut_values) / (2 ** (lut_values_bitwidth - 1)) * threshold[i]
                 self.assertTrue(len(np.unique(channel_slice_i)) <= 2 ** num_bits,
                                           f'Quantized tensor expected to have no more than {2 ** num_bits} unique values but has '
@@ -71,7 +77,7 @@ class TestPytorchWeightsLutQuantizers(unittest.TestCase):
                 # Check quantized tensor assigned correctly
                 tensor = torch.clip((input_tensor / threshold[i]) * (2 ** (lut_values_bitwidth - 1)),
                                     min=clip_min, max=clip_max)
-                tensor = tensor[:, :, :, i].unsqueeze(-1)
+                tensor = tensor[tuple(slices)].unsqueeze(-1)
                 expanded_lut_values = np.asarray(lut_values).reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
                 lut_values_assignments = torch.argmin(torch.abs(tensor - expanded_lut_values), dim=-1)
                 centers = np.asarray(lut_values).flatten()[lut_values_assignments]
@@ -81,7 +87,7 @@ class TestPytorchWeightsLutQuantizers(unittest.TestCase):
                     "Quantized tensor values weren't assigned correctly")
 
         else:
-            quant_tensor_values = lut_values / (2 ** (lut_values_bitwidth - 1)) * threshold
+            quant_tensor_values = np.asarray(lut_values) / (2 ** (lut_values_bitwidth - 1)) * threshold
             self.assertTrue(len(np.unique(fake_quantized_tensor)) <= 2 ** num_bits,
                                       f'Quantized tensor expected to have no more than {2 ** num_bits} unique values but has '
                                       f'{len(np.unique(fake_quantized_tensor))} unique values')
@@ -89,12 +95,12 @@ class TestPytorchWeightsLutQuantizers(unittest.TestCase):
                                              == np.sort(quant_tensor_values)))
 
             # Check quantized tensor assigned correctly
-            tensor = torch.clip((input_tensor / threshold) * (2 ** (lut_values_bitwidth - 1)),
+            tensor = torch.clip((input_tensor / np.asarray(threshold)) * (2 ** (lut_values_bitwidth - 1)),
                                 min=clip_min, max=clip_max)
             tensor = tensor.unsqueeze(-1)
-            expanded_lut_values = lut_values.reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
+            expanded_lut_values = np.asarray(lut_values).reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
             lut_values_assignments = torch.argmin(torch.abs(tensor - expanded_lut_values), dim=-1)
-            centers = lut_values.flatten()[lut_values_assignments]
+            centers = np.asarray(lut_values).flatten()[lut_values_assignments]
 
             self.assertTrue(
                 np.all(centers / (2 ** (lut_values_bitwidth - 1)) * threshold == fake_quantized_tensor),
@@ -170,7 +176,7 @@ class TestPytorchWeightsLutQuantizers(unittest.TestCase):
                                          input_rank=input_rank)
 
         # test per tensor
-        threshold = np.asarray([4.])
+        threshold = [4.]
         channel_axis = None
         per_channel = False
         self._weights_lut_quantizer_test(inferable_quantizer=inferable_quantizer, num_bits=num_bits,

--- a/tests/pytorch_tests/quantizers_tests/test_weights_lut_inferable_quantizer.py
+++ b/tests/pytorch_tests/quantizers_tests/test_weights_lut_inferable_quantizer.py
@@ -25,13 +25,14 @@ from mct_quantizers.pytorch.quantizers.weights_inferable_quantizers.weights_lut_
 class TestPytorchWeightsLutQuantizers(unittest.TestCase):
 
     def _weights_lut_quantizer_test(self, inferable_quantizer, num_bits, threshold, lut_values,
-                                    per_channel, channel_axis, lut_values_bitwidth):
+                                    per_channel, channel_axis, lut_values_bitwidth, input_rank):
         quantizer = inferable_quantizer(num_bits=num_bits,
                                         per_channel=per_channel,
                                         lut_values=lut_values,
                                         threshold=threshold,
                                         channel_axis=channel_axis,
-                                        lut_values_bitwidth=lut_values_bitwidth)
+                                        lut_values_bitwidth=lut_values_bitwidth,
+                                        input_rank=input_rank)
 
         # Initialize a random input to quantize between -50 to 50.
         input_tensor = torch.rand(1, 3, 3, 3) * 100 - 50
@@ -61,7 +62,7 @@ class TestPytorchWeightsLutQuantizers(unittest.TestCase):
         if per_channel:
             for i in range(len(threshold)):
                 channel_slice_i = fake_quantized_tensor[:, :, :, i]
-                channel_quant_tensor_values = lut_values / (2 ** (lut_values_bitwidth - 1)) * threshold[i]
+                channel_quant_tensor_values = np.asarray(lut_values) / (2 ** (lut_values_bitwidth - 1)) * threshold[i]
                 self.assertTrue(len(np.unique(channel_slice_i)) <= 2 ** num_bits,
                                           f'Quantized tensor expected to have no more than {2 ** num_bits} unique values but has '
                                           f'{len(np.unique(channel_slice_i))} unique values')
@@ -71,9 +72,9 @@ class TestPytorchWeightsLutQuantizers(unittest.TestCase):
                 tensor = torch.clip((input_tensor / threshold[i]) * (2 ** (lut_values_bitwidth - 1)),
                                     min=clip_min, max=clip_max)
                 tensor = tensor[:, :, :, i].unsqueeze(-1)
-                expanded_lut_values = lut_values.reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
+                expanded_lut_values = np.asarray(lut_values).reshape([*[1 for _ in range(len(tensor.shape) - 1)], -1])
                 lut_values_assignments = torch.argmin(torch.abs(tensor - expanded_lut_values), dim=-1)
-                centers = lut_values.flatten()[lut_values_assignments]
+                centers = np.asarray(lut_values).flatten()[lut_values_assignments]
 
                 self.assertTrue(
                     np.all(centers / (2 ** (lut_values_bitwidth - 1)) * threshold[i] == channel_slice_i),
@@ -105,58 +106,68 @@ class TestPytorchWeightsLutQuantizers(unittest.TestCase):
 
     def test_weights_symmetric_lut_quantizer(self):
         inferable_quantizer = WeightsLUTSymmetricInferableQuantizer
-        lut_values = np.asarray([-25, 25])
+        lut_values = [-25, 25]
         per_channel = True
         num_bits = 3
 
         # test per channel
-        threshold = np.asarray([3., 8., 7.])
+        threshold = [3., 8., 7.]
         channel_axis = 3
         lut_values_bitwidth = 8
+        input_rank = 4
         self._weights_lut_quantizer_test(inferable_quantizer=inferable_quantizer, num_bits=num_bits,
                                          threshold=threshold, lut_values=lut_values,
                                          per_channel=per_channel, channel_axis=channel_axis,
-                                         lut_values_bitwidth=lut_values_bitwidth)
+                                         lut_values_bitwidth=lut_values_bitwidth,
+                                         input_rank=input_rank)
 
         # test per channel and channel axis is not last
-        threshold = np.asarray([3., 8., 7.])
+        threshold = [3., 8., 7.]
         channel_axis = 1
         self._weights_lut_quantizer_test(inferable_quantizer=inferable_quantizer, num_bits=num_bits,
                                          threshold=threshold, lut_values=lut_values,
                                          per_channel=per_channel, channel_axis=channel_axis,
-                                         lut_values_bitwidth=lut_values_bitwidth)
+                                         lut_values_bitwidth=lut_values_bitwidth,
+                                         input_rank=input_rank)
 
         # test per tensor
-        threshold = np.asarray([3.])
+        threshold = [3.]
         channel_axis = None
         per_channel = False
         self._weights_lut_quantizer_test(inferable_quantizer=inferable_quantizer, num_bits=num_bits,
                                          threshold=threshold, lut_values=lut_values,
                                          per_channel=per_channel, channel_axis=channel_axis,
-                                         lut_values_bitwidth=lut_values_bitwidth)
+                                         lut_values_bitwidth=lut_values_bitwidth, input_rank=input_rank)
 
     def test_weights_pot_lut_quantizer(self):
         inferable_quantizer = WeightsLUTSymmetricInferableQuantizer
-        lut_values = np.asarray([-25, 25])
+        lut_values = [-25, 25]
         per_channel = True
         num_bits = 3
         lut_values_bitwidth = 7
 
         # test per channel
-        threshold = np.asarray([2., 8., 16.])
+        threshold = [2., 8., 16.]
         channel_axis = 3
-        self._weights_lut_quantizer_test(inferable_quantizer=inferable_quantizer, num_bits=num_bits,
-                                         threshold=threshold, lut_values=lut_values,
-                                         per_channel=per_channel, channel_axis=channel_axis,
-                                         lut_values_bitwidth=lut_values_bitwidth)
+        input_rank=4
+        self._weights_lut_quantizer_test(inferable_quantizer=inferable_quantizer,
+                                         num_bits=num_bits,
+                                         threshold=threshold,
+                                         lut_values=lut_values,
+                                         per_channel=per_channel,
+                                         channel_axis=channel_axis,
+                                         lut_values_bitwidth=lut_values_bitwidth,
+                                         input_rank=input_rank)
 
         # test per channel and channel axis is not last
-        threshold = np.asarray([2., 8., 16.])
+        threshold = [2., 8., 16.]
         channel_axis = 1
+        input_rank=4
         self._weights_lut_quantizer_test(inferable_quantizer=inferable_quantizer, num_bits=num_bits,
                                          threshold=threshold, lut_values=lut_values,
                                          per_channel=per_channel, channel_axis=channel_axis,
-                                         lut_values_bitwidth=lut_values_bitwidth)
+                                         lut_values_bitwidth=lut_values_bitwidth,
+                                         input_rank=input_rank)
 
         # test per tensor
         threshold = np.asarray([4.])

--- a/tests/pytorch_tests/test_pytorch_load_model.py
+++ b/tests/pytorch_tests/test_pytorch_load_model.py
@@ -93,8 +93,8 @@ class TestPytorchLoadModel(unittest.TestCase):
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_activation_lut_pot(self):
-        lut_values = np.asarray([-25, 25])
-        thresholds = np.asarray([4.])
+        lut_values = [-25, 25]
+        thresholds = [4.]
         num_bits = 3
         signed = True
         lut_values_bitwidth = 8
@@ -147,10 +147,10 @@ class TestPytorchLoadModel(unittest.TestCase):
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_weights_lut_symmetric(self):
-        lut_values = np.asarray([-25, 25])
+        lut_values = [-25, 25]
         per_channel = True
         num_bits = 8
-        threshold = np.asarray([3., 8., 7.])
+        threshold = [3., 8., 7.]
         channel_axis = 3
         lut_values_bitwidth = 8
         eps = 1e-8
@@ -160,16 +160,17 @@ class TestPytorchLoadModel(unittest.TestCase):
                                                           per_channel=per_channel,
                                                           channel_axis=channel_axis,
                                                           lut_values_bitwidth=lut_values_bitwidth,
-                                                          eps=eps)
+                                                          eps=eps,
+                                                          input_rank=4)
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 10, 3),
                                                           {'weight': quantizer}).to(self.device)
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_weights_lut_pot(self):
-        lut_values = np.asarray([-25, 25])
+        lut_values = [-25, 25]
         per_channel = True
         num_bits = 8
-        threshold = np.asarray([1., 8., 4.])
+        threshold = [1., 8., 4.]
         channel_axis = 3
         lut_values_bitwidth = 8
         eps = 1e-8
@@ -179,7 +180,8 @@ class TestPytorchLoadModel(unittest.TestCase):
                                                     per_channel=per_channel,
                                                     channel_axis=channel_axis,
                                                     lut_values_bitwidth=lut_values_bitwidth,
-                                                    eps=eps)
+                                                    eps=eps,
+                                                    input_rank=4)
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 10, 3),
                                                           {'weight': quantizer}).to(self.device)
         self._one_layer_model_save_and_load(layer_with_quantizer)


### PR DESCRIPTION
Add pytorch LUT quantizers an option to be exported in ONNX.
Change LUT quantizers API to receive lists instead of np arrays (for lut values and thresholds).
Adapt all LUT tests that pass np arrays to lists.
Fix the issue with ignoring the channel axis in LUT quantizers (and tests that assumed the channel axis is always 0)



