### PR TITLE
Fix issue in per-tensor quantization and missing channel_axis

### DIFF
--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_pot_inferable_quantizer.py
@@ -152,6 +152,12 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
+            # When None is passed as channel_axis, the op has no attribute of channel_axis,
+            # which creates conflict with the onnxruntime function. For this reason, if we quantize
+            # per-tensor and channel_axis is None, we set it to 0.
+            if not per_channel and channel_axis is None:
+                channel_axis = 0
+
             return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsLUTPOTQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(lut_values, dtype=torch.float32)),
                         g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_lut_symmetric_inferable_quantizer.py
@@ -174,6 +174,12 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
+            # When None is passed as channel_axis, the op has no attribute of channel_axis,
+            # which creates conflict with the onnxruntime function. For this reason, if we quantize
+            # per-tensor and channel_axis is None, we set it to 0.
+            if not per_channel and channel_axis is None:
+                channel_axis = 0
+
             return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsLUTSymmetricQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(lut_values, dtype=torch.float32)),
                         g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_pot_inferable_quantizer.py
@@ -130,6 +130,12 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
+            # When None is passed as channel_axis, the op has no attribute of channel_axis,
+            # which creates conflict with the onnxruntime function. For this reason, if we quantize
+            # per-tensor and channel_axis is None, we set it to 0.
+            if not per_channel and channel_axis is None:
+                channel_axis = 0
+
             return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsPOTQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
                         num_bits_i=num_bits,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_symmetric_inferable_quantizer.py
@@ -189,6 +189,12 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
+            # When None is passed as channel_axis, the op has no attribute of channel_axis,
+            # which creates conflict with the onnxruntime function. For this reason, if we quantize
+            # per-tensor and channel_axis is None, we set it to 0.
+            if not per_channel and channel_axis is None:
+                channel_axis = 0
+
             return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsSymmetricQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(threshold, dtype=torch.float32)),
                         num_bits_i=num_bits,

--- a/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
+++ b/mct_quantizers/pytorch/quantizers/weights_inferable_quantizers/weights_uniform_inferable_quantizer.py
@@ -204,6 +204,12 @@ if FOUND_TORCH:
             Returns:
                 The node in the ONNX graph representing the output of this operation.
             """
+            # When None is passed as channel_axis, the op has no attribute of channel_axis,
+            # which creates conflict with the onnxruntime function. For this reason, if we quantize
+            # per-tensor and channel_axis is None, we set it to 0.
+            if not per_channel and channel_axis is None:
+                channel_axis = 0
+
             return g.op(f"{ONNX_CUSTOM_OP_DOMAIN}::WeightsUniformQuantizer", input_tensor,
                         g.op('Constant', value_t=torch.tensor(min_range, dtype=torch.float32)),
                         g.op('Constant', value_t=torch.tensor(max_range, dtype=torch.float32)),

--- a/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
+++ b/tests/pytorch_tests/onnx_export_tests/test_weight_quantizers.py
@@ -167,12 +167,10 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         thresholds = [3.]
         num_bits = 2
         per_channel = False
-        channel_axis = 0
 
         quantizer = pytorch_quantizers.WeightsSymmetricInferableQuantizer(num_bits=num_bits,
                                                                           per_channel=per_channel,
                                                                           threshold=thresholds,
-                                                                          channel_axis=channel_axis
                                                                           )
         quantizer.enable_custom_impl()
 
@@ -200,8 +198,7 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
         assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
         assert np.all(thresholds==onnx_threshold), f'Expected threshold in quantizer to be {thresholds} but found {onnx_threshold}'
-        assert onnx_channel_axis == channel_axis, f'Expected threshold in quantizer to be {channel_axis} but found ' \
-                                             f'{onnx_channel_axis}'
+
         onnx_signed = node_qparams['signed']
         assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
 
@@ -210,12 +207,10 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         thresholds = [0.5]
         num_bits = 2
         per_channel = False
-        channel_axis = 0
 
         quantizer = pytorch_quantizers.WeightsPOTInferableQuantizer(num_bits=num_bits,
                                                                     per_channel=per_channel,
-                                                                    threshold=thresholds,
-                                                                    channel_axis=channel_axis
+                                                                    threshold=thresholds
                                                                     )
         quantizer.enable_custom_impl()
 
@@ -240,8 +235,7 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         assert onnx_nbits == num_bits, f'Expected num_bits in quantizer to be {num_bits} but found {onnx_nbits}'
         assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
         assert np.all(thresholds==onnx_threshold), f'Expected threshold in quantizer to be {thresholds} but found {onnx_threshold}'
-        assert onnx_channel_axis == channel_axis, f'Expected threshold in quantizer to be {channel_axis} but found ' \
-                                             f'{onnx_channel_axis}'
+
         onnx_signed = node_qparams['signed']
         assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
         assert node_qparams[MCTQ_VERSION] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams[MCTQ_VERSION]}'
@@ -252,13 +246,11 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         max_range = [0.5]
         num_bits = 2
         per_channel = False
-        channel_axis = 0
 
         quantizer = pytorch_quantizers.WeightsUniformInferableQuantizer(num_bits=num_bits,
                                                                         min_range=min_range,
                                                                         max_range=max_range,
-                                                                        per_channel=per_channel,
-                                                                        channel_axis=channel_axis)
+                                                                        per_channel=per_channel)
         quantizer.enable_custom_impl()
 
 
@@ -286,7 +278,6 @@ class TestONNXExportWeightsQuantizers(unittest.TestCase):
         assert onnx_per_channel == per_channel, f'Expected per_channel in quantizer to be {per_channel} but found {onnx_per_channel}'
         assert np.all(np.zeros(shape=(1,))==onnx_min_range), f'Expected min_range in quantizer to be zeros after range adjustment but found {onnx_min_range}'
         assert np.all(max_range==onnx_max_range), f'Expected max_range in quantizer to be {max_range} but found {onnx_max_range}'
-        assert onnx_channel_axis == channel_axis, f'Expected channel_axis in quantizer to be {channel_axis} but found {onnx_channel_axis}'
         onnx_signed = node_qparams['signed']
         assert onnx_signed == True, f'Expected signed in weight quantizer to be True but is {onnx_signed}'
         assert node_qparams[MCTQ_VERSION] == mctq_version, f'Expected version to be {mctq_version} but is {node_qparams[MCTQ_VERSION]}'


### PR DESCRIPTION
When None is passed as channel_axis, the op has no attribute of channel_axis, which creates conflict with the onnxruntime function. For this reason, if we quantize per-tensor and channel_axis is None, we set it to 0.