### PR TITLE
Make sure to store extracted weights names in KerasQuantizationWrapper

### DIFF
--- a/mct_quantizers/keras/quantize_wrapper.py
+++ b/mct_quantizers/keras/quantize_wrapper.py
@@ -66,7 +66,10 @@ if FOUND_TF:
             """
             super(KerasQuantizationWrapper, self).__init__(layer, **kwargs)
             self._track_trackable(layer, name='layer')
-            self.weights_quantizers = weights_quantizers if weights_quantizers is not None else dict()
+
+            # making sure the attribute name is converted to the actual attribute field name in the layer.
+            self.weights_quantizers = {_weight_name(k): v for k, v in weights_quantizers.items()} \
+                if weights_quantizers is not None else dict()
 
             self._mctq_version = mctq_version
 
@@ -128,6 +131,7 @@ if FOUND_TF:
             """
             self._weights_vars = []
             for name, quantizer in self.weights_quantizers.items():
+                name = _weight_name(name)
                 weight = getattr(self.layer, name)
                 quantizer.initialize_quantization(weight.shape, _weight_name(weight.name) if is_training else None,
                                                   self)

--- a/mct_quantizers/keras/quantize_wrapper.py
+++ b/mct_quantizers/keras/quantize_wrapper.py
@@ -84,7 +84,8 @@ if FOUND_TF:
             Returns: None
 
             """
-            self.weights_quantizers.update({param_name: quantizer})
+            fixed_name = _weight_name(param_name)
+            self.weights_quantizers.update({fixed_name: quantizer})
 
         @property
         def is_weights_quantization(self) -> bool:
@@ -131,7 +132,6 @@ if FOUND_TF:
             """
             self._weights_vars = []
             for name, quantizer in self.weights_quantizers.items():
-                name = _weight_name(name)
                 weight = getattr(self.layer, name)
                 quantizer.initialize_quantization(weight.shape, _weight_name(weight.name) if is_training else None,
                                                   self)


### PR DESCRIPTION
## Pull Request Description:
To support attribute quantization for attributes besides the kernel, we need to make sure that the quantization wrapper stores the attributes with their object's variable name.
This change won't affect the current behavior of the wrapper.

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [x] I have added/updated the release note draft (if necessary).
- [x] I have updated the documentation to reflect my changes (if necessary).
- [x] All function and files are well documented. 
- [x] All function and classes have type hints.
- [x] There is a licenses in all file.
- [x] The function and variable names are informative. 
- [x] I have checked for code duplications.
- [x] I have added new unittest (if necessary).