### PR TITLE
Support positional Constants in Wrappers

### DIFF
--- a/mct_quantizers/common/constants.py
+++ b/mct_quantizers/common/constants.py
@@ -35,6 +35,10 @@ FOUND_ONNXRUNTIME_EXTENSIONS = importlib.util.find_spec(ONNXRUNTIME_EXTENSIONS) 
 IS_WEIGHTS = "is_weights"
 IS_ACTIVATIONS = "is_activations"
 WEIGHTS_QUANTIZERS = "weights_quantizer"
+WEIGHTS_VALUES = "weights_value"
+OP_CALL_ARGS = 'op_call_args'
+OP_CALL_KWARGS = 'op_call_kwargs'
+IS_INPUT_AS_LIST = 'is_inputs_as_list'
 WEIGHTS_QUANTIZATION_METHOD = 'weights_quantization_method'
 WEIGHTS_N_BITS = 'weights_n_bits'
 WEIGHTS_QUANTIZATION_PARAMS = 'weights_quantization_params'
@@ -79,6 +83,9 @@ TRAINING = "training"
 EPS = 1e-8
 LUT_VALUES_BITWIDTH = 8
 MCTQ_VERSION = "mctq_version"
+
+POSITIONAL_WEIGHT = 'positional_weight'
+QUANTIZED_POSITIONAL_WEIGHT = f'quantized_{POSITIONAL_WEIGHT}'
 
 # ONNX ops domain
 ONNX_CUSTOM_OP_DOMAIN = f"mct_quantizers"

--- a/mct_quantizers/keras/quantize_wrapper.py
+++ b/mct_quantizers/keras/quantize_wrapper.py
@@ -137,20 +137,6 @@ if FOUND_TF:
 
             self._mctq_version = mctq_version
 
-        def add_weights_quantizer(self, param_name: str, quantizer: BaseInferableQuantizer):
-            """
-            This function adds a weights quantizer to existing wrapper
-
-            Args:
-                param_name: The name of the parameter to quantize
-                quantizer: A quantizer.
-
-            Returns: None
-
-            """
-            fixed_name = _weight_name(param_name)
-            self.weights_quantizers.update({fixed_name: quantizer})
-
         @property
         def is_weights_quantization(self) -> bool:
             """
@@ -361,7 +347,7 @@ if FOUND_TF:
                 _inputs = inputs if isinstance(inputs, list) else [inputs]
                 weight_positions = [w[0] for w in self._weights_vars]
                 for pos in sorted(weight_positions):
-                    _inputs.insert(pos, getattr(self, f'quantized_positional_weight_{pos}'))
+                    _inputs.insert(pos, getattr(self, f'{QUANTIZED_POSITIONAL_WEIGHT}_{pos}'))
 
                 if self.is_inputs_as_list:
                     outputs = self.layer.call(_inputs, *self.op_call_args, **self.op_call_kwargs)
@@ -397,7 +383,7 @@ else:
     class KerasQuantizationWrapper:
         def __init__(self,
                      layer,
-                     weights_quantizers: Dict[str, BaseInferableQuantizer] = None):
+                     weights_quantizers: Dict[str, BaseInferableQuantizer]):
             """
             Keras Quantization Wrapper takes a keras layer and quantizers and infer a quantized layer.
 

--- a/tests/compatibility_tests/keras_comp_tests/base_weights_compatibility_test.py
+++ b/tests/compatibility_tests/keras_comp_tests/base_weights_compatibility_test.py
@@ -156,8 +156,7 @@ class BaseWeightsQuantizerBuildAndSaveTest(unittest.TestCase):
 
         weights_quantizer = quantizer(**quantizer_params)
 
-        quant_weights_layer = KerasQuantizationWrapper(layer)
-        quant_weights_layer.add_weights_quantizer(weight_name, weights_quantizer)
+        quant_weights_layer = KerasQuantizationWrapper(layer, {weight_name: weights_quantizer})
 
         model = _build_model_with_quantize_wrapper(quant_weights_layer=quant_weights_layer,
                                                    input_shape=input_shape,

--- a/tests/keras_tests/test_keras_quantization_wrapper.py
+++ b/tests/keras_tests/test_keras_quantization_wrapper.py
@@ -51,13 +51,29 @@ class TestKerasQuantizationWrapper(unittest.TestCase):
 
         inputs = layers.Input(shape=self.input_shapes[0][1:])
         x = layers.Conv2D(6, 7, use_bias=False)(inputs)
+        self.sub_const = np.random.random(x.shape[-1]).astype(np.float32)
+        x = tf.subtract(self.sub_const, x)
+        self.mul_const = np.random.random((1, *x.shape[1:].as_list()))
+        x = tf.keras.layers.Multiply()([x, self.mul_const])
+        self.matmul_cont = np.random.random((2, x.shape[-1])).astype(np.float32)
+        x = tf.matmul(x, self.matmul_cont, transpose_b=True)
         self.model = keras.Model(inputs=inputs, outputs=x)
+        self.output_shapes = [(1, *x.shape[1:].as_list())]
 
     def test_weights_quantization_wrapper(self):
-        conv_layer = self.model.layers[1]
+        _, conv_layer, sub_layer, mul_layer, matmul_layer = self.model.layers
 
-        wrapper = KerasQuantizationWrapper(conv_layer)
-        wrapper.add_weights_quantizer(WEIGHT, IdentityWeightsQuantizer())
+        wrapper = KerasQuantizationWrapper(conv_layer, {WEIGHT: IdentityWeightsQuantizer()})
+
+        sub_wrapper = KerasQuantizationWrapper(sub_layer, {0: IdentityWeightsQuantizer()},
+                                               {0: self.sub_const})
+        mul_wrapper = KerasQuantizationWrapper(mul_layer, {1: IdentityWeightsQuantizer()},
+                                               {1: self.mul_const},
+                                               is_inputs_as_list=True)
+        matmul_wrapper = KerasQuantizationWrapper(matmul_layer, {1: IdentityWeightsQuantizer()},
+                                                  {1: self.matmul_cont},
+                                                  op_call_args=[False],
+                                                  op_call_kwargs={'transpose_b': True})
 
         # build
         wrapper.build(self.input_shapes)
@@ -68,8 +84,35 @@ class TestKerasQuantizationWrapper(unittest.TestCase):
         self.assertTrue((weight == getattr(wrapper.layer, WEIGHT)).numpy().all())
         self.assertTrue(isinstance(quantizer, IdentityWeightsQuantizer))
 
+        sub_wrapper.build(self.output_shapes)
+        (name, weight, quantizer) = sub_wrapper._weights_vars[0]
+        self.assertTrue(isinstance(sub_wrapper, KerasQuantizationWrapper))
+        self.assertTrue(sub_wrapper.layer.function is tf.subtract)
+        self.assertTrue(name == 0)
+        self.assertTrue((weight == getattr(sub_wrapper, f'positional_weight_{name}')).numpy().all())
+        self.assertTrue(isinstance(quantizer, IdentityWeightsQuantizer))
+
+        mul_wrapper.build(self.output_shapes)
+        (name, weight, quantizer) = mul_wrapper._weights_vars[0]
+        self.assertTrue(isinstance(mul_wrapper, KerasQuantizationWrapper))
+        self.assertTrue(isinstance(mul_wrapper.layer, tf.keras.layers.Multiply))
+        self.assertTrue(name == 1)
+        self.assertTrue((weight == getattr(mul_wrapper, f'positional_weight_{name}')).numpy().all())
+        self.assertTrue(isinstance(quantizer, IdentityWeightsQuantizer))
+
+        matmul_wrapper.build(self.output_shapes)
+        (name, weight, quantizer) = matmul_wrapper._weights_vars[0]
+        self.assertTrue(isinstance(matmul_wrapper, KerasQuantizationWrapper))
+        self.assertTrue(matmul_wrapper.layer.function is tf.matmul)
+        self.assertTrue(name == 1)
+        self.assertTrue((weight == getattr(matmul_wrapper, f'positional_weight_{name}')).numpy().all())
+        self.assertTrue(isinstance(quantizer, IdentityWeightsQuantizer))
+
         # call
         call_inputs = self.inputs[0]
-        outputs = wrapper.call(call_inputs.astype('float32'))
-        self.assertTrue((outputs == conv_layer(call_inputs)).numpy().all())
-
+        model_output = self.model(call_inputs)
+        x = wrapper.call(call_inputs.astype('float32'))
+        x = sub_wrapper.call(x)
+        x = mul_wrapper.call(x)
+        wrappers_output = matmul_wrapper.call(x)
+        self.assertTrue((wrappers_output == model_output).numpy().all())

--- a/tests/pytorch_tests/test_pytorch_load_model.py
+++ b/tests/pytorch_tests/test_pytorch_load_model.py
@@ -122,6 +122,15 @@ class TestPytorchLoadModel(unittest.TestCase):
                                                           {'weight': quantizer}).to(self.device)
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
+        quantizer = WeightsPOTInferableQuantizer(num_bits=num_bits,
+                                                 per_channel=False,
+                                                 threshold=[1.0])
+        layer_with_quantizer = PytorchQuantizationWrapper(torch.sub,
+                                                          {0: quantizer},
+                                                          weight_values={0: torch.ones((3, 1, 1)).to(self.device)}
+                                                          ).to(self.device)
+        self._one_layer_model_save_and_load(layer_with_quantizer)
+
     def test_save_and_load_weights_symmetric(self):
         thresholds = [3., 6., 2.]
         num_bits = 2
@@ -131,6 +140,17 @@ class TestPytorchLoadModel(unittest.TestCase):
                                                        channel_axis=3)
         layer_with_quantizer = PytorchQuantizationWrapper(torch.nn.Conv2d(3, 10, 3),
                                                           {'weight': quantizer}).to(self.device)
+        self._one_layer_model_save_and_load(layer_with_quantizer)
+
+        quantizer = WeightsSymmetricInferableQuantizer(num_bits=num_bits,
+                                                       per_channel=False,
+                                                       threshold=[1.0])
+        layer_with_quantizer = PytorchQuantizationWrapper(torch.cat,
+                                                          {0: quantizer, 2: quantizer},
+                                                          weight_values={0: torch.ones((1, 2, 99, 99)).to(self.device),
+                                                                         2: torch.ones((1, 4, 99, 99)).to(self.device)},
+                                                          op_call_args=[1], is_inputs_as_list=True
+                                                          ).to(self.device)
         self._one_layer_model_save_and_load(layer_with_quantizer)
 
     def test_save_and_load_weights_uniform(self):

--- a/tests/pytorch_tests/test_pytorch_quantization_wrapper.py
+++ b/tests/pytorch_tests/test_pytorch_quantization_wrapper.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 import numpy as np
 
+from mct_quantizers.common.constants import POSITIONAL_WEIGHT, QUANTIZED_POSITIONAL_WEIGHT
 from mct_quantizers.pytorch.quantize_wrapper import PytorchQuantizationWrapper
 
 WEIGHT = 'weight'
@@ -62,20 +63,66 @@ class ZeroActivationsQuantizer:
 class TestPytorchWeightsQuantizationWrapper(unittest.TestCase):
 
     def setUp(self):
-        self.input_shapes = [(1, 3, 8, 8)]
-        self.inputs = [np.random.randn(*in_shape) for in_shape in self.input_shapes]
-        self.layer = nn.Conv2d(3, 20, 3)
+        self.input_shapes = (1, 3, 8, 8)
+        self.inputs = torch.from_numpy(np.random.randn(*self.input_shapes).astype(dtype=np.float32))
+        self.sub_const = torch.from_numpy(np.random.randn(*self.input_shapes[1:]).astype(dtype=np.float32))
+        self.linear_const = torch.from_numpy(np.random.randn(self.input_shapes[-1], 7).astype(dtype=np.float32))
+        self.cat_const1 = torch.from_numpy(np.random.randn(*self.input_shapes).astype(dtype=np.float32))
+        self.cat_const2 = torch.from_numpy(np.random.randn(*self.input_shapes).astype(dtype=np.float32))
+        self.layers = [nn.Conv2d(3, 20, 3),
+                       torch.sub,
+                       torch.cat,
+                       ]
 
     def test_weights_quantization_wrapper(self):
-        wrapper = PytorchQuantizationWrapper(self.layer)
-        wrapper.add_weights_quantizer('weight', ZeroWeightsQuantizer())
-        wrapper._set_weights_vars()
+        wrapper = PytorchQuantizationWrapper(self.layers[0], {'weight': ZeroWeightsQuantizer()})
         (name, weight, quantizer) = wrapper._weights_vars[0]
         self.assertTrue(isinstance(wrapper, PytorchQuantizationWrapper))
         self.assertTrue(isinstance(wrapper.layer, nn.Conv2d))
         self.assertTrue(name == 'weight')
         self.assertTrue((weight == getattr(wrapper.layer, 'weight')).any())
         self.assertTrue(isinstance(quantizer, ZeroWeightsQuantizer))
-        y = wrapper(torch.Tensor(self.inputs[0])) # apply the wrapper on some random inputs
-        self.assertTrue((0 == getattr(wrapper.layer, 'weight')).any()) # check the weight are now quantized
-        self.assertTrue((y[0,:,0,0] == getattr(wrapper.layer, 'bias')).any()) # check the wrapper's outputs are equal to biases
+        y = wrapper(torch.Tensor(self.inputs))  # apply the wrapper on some random inputs
+        self.assertTrue((0 == getattr(wrapper.layer, 'weight')).any())  # check the weight are now quantized
+        self.assertTrue((y[0, :, 0, 0] == getattr(wrapper.layer, 'bias')).any())  # check the wrapper's outputs are equal to biases
+
+        wrapper = PytorchQuantizationWrapper(self.layers[1], {0: ZeroWeightsQuantizer()},
+                                             weight_values={0: self.sub_const})
+        (name, weight, quantizer) = wrapper._weights_vars[0]
+        self.assertTrue(isinstance(wrapper, PytorchQuantizationWrapper))
+        self.assertTrue(wrapper.layer is torch.sub)
+        self.assertTrue(name == 0)
+        self.assertTrue((weight == getattr(wrapper, f'{POSITIONAL_WEIGHT}_{name}')).all())
+        self.assertTrue(isinstance(quantizer, ZeroWeightsQuantizer))
+        y = wrapper(self.inputs)  # apply the wrapper on some random inputs
+        self.assertTrue((0 == getattr(wrapper, f'{QUANTIZED_POSITIONAL_WEIGHT}_{name}')).all())  # check the weight are now quantized
+        self.assertTrue((y == self.layers[1](torch.zeros_like(self.sub_const), self.inputs)).all())  # check the wrapper's outputs are equal to biases
+
+        wrapper = PytorchQuantizationWrapper(self.layers[1], {0: ZeroWeightsQuantizer()},
+                                             weight_values={0: self.sub_const})
+        (name, weight, quantizer) = wrapper._weights_vars[0]
+        self.assertTrue(isinstance(wrapper, PytorchQuantizationWrapper))
+        self.assertTrue(wrapper.layer is torch.sub)
+        self.assertTrue(name == 0)
+        self.assertTrue((weight == getattr(wrapper, f'{POSITIONAL_WEIGHT}_{name}')).all())
+        self.assertTrue(isinstance(quantizer, ZeroWeightsQuantizer))
+        y = wrapper(self.inputs)  # apply the wrapper on some random inputs
+        self.assertTrue((0 == getattr(wrapper, f'{QUANTIZED_POSITIONAL_WEIGHT}_{name}')).all())  # check the weight are now quantized
+        self.assertTrue((y == self.layers[1](torch.zeros_like(self.sub_const), self.inputs)).all())  # check the wrapper's outputs are equal to biases
+
+        wrapper = PytorchQuantizationWrapper(self.layers[2], {0: ZeroWeightsQuantizer(), 2: ZeroWeightsQuantizer()},
+                                             weight_values={0: self.cat_const1, 2: self.cat_const2},
+                                             op_call_kwargs={'dim': 1}, is_inputs_as_list=True)
+        (name, weight, quantizer) = wrapper._weights_vars[0]
+        self.assertTrue(isinstance(wrapper, PytorchQuantizationWrapper))
+        self.assertTrue(wrapper.layer is torch.cat)
+        self.assertTrue([wv[0] for wv in wrapper._weights_vars] == [0, 2])
+        self.assertTrue((weight == getattr(wrapper, f'{POSITIONAL_WEIGHT}_{name}')).all())
+        self.assertTrue(isinstance(quantizer, ZeroWeightsQuantizer))
+        y = wrapper(self.inputs)  # apply the wrapper on some random inputs
+        self.assertTrue((0 == getattr(wrapper, f'{QUANTIZED_POSITIONAL_WEIGHT}_0')).all())  # check the weight are now quantized
+        self.assertTrue((0 == getattr(wrapper, f'{QUANTIZED_POSITIONAL_WEIGHT}_2')).all())  # check the weight are now quantized
+        self.assertTrue((y == self.layers[2]([torch.zeros_like(self.cat_const1),
+                                              self.inputs,
+                                              torch.zeros_like(self.cat_const2)],
+                                             **wrapper.op_call_kwargs)).all())  # check the wrapper's outputs are equal to biases


### PR DESCRIPTION
## Pull Request Description:
This PR adds the ability to quantize constants that are not attributes of layers (e.g. quantize the cosntant 2.9965 in y=tf.add(x, 2.9965), both in Keras and PyTorch.
Checkout the documentations of KerasQuantizationWrapper and PytorchQuantizationWrapper for more information.

## Checklist before requesting a review:
- [ ] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).