### PR TITLE
[RedSuns, SSS Review]Fix CI/CD error of Test pip install when Python3.12

### DIFF
--- a/.github/workflows/run_tests_suite_pip.yml
+++ b/.github/workflows/run_tests_suite_pip.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install twine wheel
+          pip install twine wheel setuptools
       - name: Build WHL file
         run: |
           version=$(python -c 'import mct_quantizers; print(mct_quantizers.__version__)')
@@ -42,9 +42,11 @@ jobs:
         run: |
           rm -rf mct_quantizers
       - name: Install TF
+        if: ${{ inputs.python_version != '3.12' }}
         run: |
           pip install tensorflow==2.15.*
       - name: Run TF Tests
+        if: ${{ inputs.python_version != '3.12' }}
         run: |
           python -m unittest discover tests/keras_tests --verbose
       - name: Prepare for Torch


### PR DESCRIPTION
## Pull Request Description:
* Fix CI/CD error of Test pip install when Python3.12 (same of #147 )
  * Add install setuptools
  * Skip TF test when Python3.12

## Checklist before requesting a review:
- [x] I set the appropriate labels on the pull request.
- [ ] I have added/updated the release note draft (if necessary).
- [ ] I have updated the documentation to reflect my changes (if necessary).
- [ ] All function and files are well documented. 
- [ ] All function and classes have type hints.
- [ ] There is a licenses in all file.
- [ ] The function and variable names are informative. 
- [ ] I have checked for code duplications.
- [ ] I have added new unittest (if necessary).